### PR TITLE
Ignore *.iml instead of streetcomplete.iml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /build
 /captures
 /rejected
-streetcomplete.iml
+*.iml
 view_db.bat
 view_test_db.bat
 *.ignore


### PR DESCRIPTION
Tells Git to ignore all `*.iml` files not just `streetcomplete.iml` in case the project is cloned into a folder named something other than `streetcomplete` (i.e. street-complete, StreetComplete, etc.)