### PR TITLE
Remove acute accent in language name

### DIFF
--- a/app/src/main/res/values/untranslatableStrings.xml
+++ b/app/src/main/res/values/untranslatableStrings.xml
@@ -16,7 +16,7 @@
         Nederlands  - Alert Bouterse, Maikel de Vries, Kenny)&lt;br/&gt;
         Polski      - Anett Sichla, Tomasz Maciejewski&lt;br/&gt;
         Português   - Patrick Montenegro&lt;br/&gt;
-        Ру́сский     - Anton Shestakov, zetx16&lt;br/&gt;
+        Русский     - Anton Shestakov, zetx16&lt;br/&gt;
         Svenska     - Erik, Henrik Gripenberg&lt;br/&gt;
         Türkçe      - Nesim&lt;br/&gt;
         繁体中文     - Kagami&lt;br/&gt;


### PR DESCRIPTION
I guess acute accent here came from a wikipedia article or a dictionary. In real life it's only used to help language learners, to distinguish between homographic words or to explicitly put stress on a specific word.