### PR TITLE
allow very large map cache

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -45,7 +45,7 @@
             android:defaultValue="50"
             android:persistent="true"
             custom:minValue="1"
-            custom:maxValue="250"
+            custom:maxValue="2500"
             android:dialogMessage="@string/pref_tilecache_size_message"
             android:dialogLayout="@layout/numberpicker_preference"
             android:positiveButtonText="@android:string/ok"


### PR DESCRIPTION
at least for some users it is preferable to keep massive cache rather than attempt to download map while surveying
this commit changes limit of map cache size setting to extremely high value so this will not limit users of this type
fixes #208