### PR TITLE
Remove non-swiss ß character from abbreviations

### DIFF
--- a/app/src/main/res/raw-de-rCH/abbreviations.yml
+++ b/app/src/main/res/raw-de-rCH/abbreviations.yml
@@ -1,5 +1,5 @@
 # only add common ones which native speakers would actually use. See default file for syntax
-Gr: Groß
+Gr: Gross
 Kl: Klein
 Prof: Professor
 ...pl$: platz


### PR DESCRIPTION
Hi - this fixes the swiss version of Groß - someone did this for strasse and chaussee already.