### PR TITLE
Display bus stop name only if it exist

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/BusStopShelterForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bus_stop_shelter/BusStopShelterForm.java
@@ -23,9 +23,9 @@ public class BusStopShelterForm extends YesNoQuestAnswerFragment
 	private void setTitle()
 	{
 		OsmElement element = getOsmElement();
-		if(element != null && element.getTags() != null)
+		String name = element != null && element.getTags() != null ? element.getTags().get("name") : null;
+		if(name != null && !name.trim().isEmpty())
 		{
-			String name = element.getTags().get("name");
 			setTitle(getResources().getString(R.string.quest_busStopShelter_name_title, name));
 		}
 		else


### PR DESCRIPTION
Bug fix. Prevent the message "Does the bus stop null have a shelter?" to be displayed.
![screenshot_20170523-134155](https://cloud.githubusercontent.com/assets/6597721/26376966/bad3c6be-400e-11e7-88b5-69dd17edf545.png)
