### PR TITLE
Display housenumbers and bus stops on basemap

### DIFF
--- a/app/src/main/assets/cinnabar-style-7.0.0.yaml
+++ b/app/src/main/assets/cinnabar-style-7.0.0.yaml
@@ -130,11 +130,7 @@ global:
     ux_language_text_source_building_and_address: |
         function() {
             var name = (global.ux_language && feature['name:'+global.ux_language]) || (global.ux_language_fallback && feature['name:'+global.ux_language_fallback]) || feature['name'];
-            if (name && feature.addr_housenumber) {
-                return name + '\n' + feature.addr_housenumber;
-            } else {
-                return name;
-            }
+            return name;
         }
 
     # To facilitate data visualizations several recommended sort orders are provided

--- a/app/src/main/assets/cinnabar-style-7.0.0.yaml
+++ b/app/src/main/assets/cinnabar-style-7.0.0.yaml
@@ -3607,7 +3607,7 @@ layers:
             filter:
                 all:
                     - function() { return global.text_visible_address; }
-                    - $zoom: { min: 20 }
+                    - $zoom: { min: 18 }
                 any:
                     - kind: address
                     - { label_position: true, addr_housenumber: true, name: false }
@@ -3617,7 +3617,7 @@ layers:
                     order: 7
                     text_source: addr_housenumber
                     font:
-                        fill: global.text_fill_address
+                        fill: global.text_fill
                         family: global.text_font_family
                         style: italic
                         size: 10px

--- a/app/src/main/assets/cinnabar-style-7.0.0.yaml
+++ b/app/src/main/assets/cinnabar-style-7.0.0.yaml
@@ -5092,17 +5092,18 @@ layers:
                 kind: [bus_stop]
             draw:
                 icons:
-                    size: 14px
+                    visible: true
+                    size: 20px
                     text:
                         font:
                             size: 11px
                             weight: normal
             later:
-                filter: { $zoom: { max: 19 } }
+                filter: { $zoom: { min: 19 } }
                 draw:
                     icons:
                         text:
-                            visible: false
+                            visible: true
 
         airport-gate:
             filter: { kind: aeroway_gate }

--- a/app/src/main/assets/cinnabar-style-7.0.0.yaml
+++ b/app/src/main/assets/cinnabar-style-7.0.0.yaml
@@ -3563,9 +3563,9 @@ layers:
                     - { $zoom: [17], area: { min: 2000 }, kind_detail: [university, college, school, kindergarten] }
                     - { $zoom: [18], area: { min: 1000 } }
                     - { $zoom: [18], kind_detail: [university, college, school, kindergarten] }
-                    - { $zoom: [19], area: { min: 200 } }
-                    - { $zoom: { min: 19 }, kind_detail: [university, college, school, kindergarten] }
-                    - { $zoom: { min: 20 }, area: true }
+                    - { $zoom: [18], area: { min: 200 } }
+                    - { $zoom: { min: 18 }, kind_detail: [university, college, school, kindergarten] }
+                    - { $zoom: { min: 18 }, area: true }
             draw:
                 text-blend-order:
                     #interactive: global.sdk_interactive
@@ -3584,7 +3584,7 @@ layers:
                 draw: { text-blend-order: { font: { size: 12px, stroke: { width: 2 } } } }
             building_labels-z18:
                 filter: { $zoom: [18,19] }
-                draw: { text-blend-order: { font: { size: 12px, weight: 600, stroke: { width: 3 } } } }
+                draw: { text-blend-order: { font: { size: 10px, weight: 600, stroke: { width: 3 } } } }
             building_labels-z20-up:
                 filter: { $zoom: { min: 20 } }
                 draw: { text-blend-order: { font: { size: 14px, weight: 600, stroke: { width: 3 }  } } }
@@ -3598,8 +3598,8 @@ layers:
                 draw:
                     text-blend-order:
                         visible: false
-            building-labels-z20+:
-                filter: { $zoom: { min: 20 } }
+            building-labels-z18+:
+                filter: { $zoom: { min: 18 } }
                 draw:
                     text-blend-order:
                         text_source: global.ux_language_text_source_building_and_address

--- a/app/src/main/assets/cinnabar-style-7.0.0.yaml
+++ b/app/src/main/assets/cinnabar-style-7.0.0.yaml
@@ -219,8 +219,8 @@ global:
     icon_visible_populated_places:  true
     text_visible_neighbourhoods:    true
     text_visible_neighbourhoods_e:  true
-    text_visible_building:          false     # false for default
-    text_visible_address:           false     # false for default
+    text_visible_building:          true     # false for default
+    text_visible_address:           true     # false for default
     text_visible_water_labels:      true
     text_visible_island:            true
     label_visible_landuse_green:    true

--- a/app/src/main/assets/cinnabar-style-7.0.0.yaml
+++ b/app/src/main/assets/cinnabar-style-7.0.0.yaml
@@ -3573,17 +3573,17 @@ layers:
                         fill: global.text_fill
                         family: global.text_font_family
                         style: italic
-                        size: 11px
-                        stroke: { color: global.text_stroke_address, width: 1 }
+                        size: 10px
+                        stroke: { color: global.building1, width: 4 }
             building_labels-z15-z16-z17:
                 filter: { $zoom: [15,16,17] }
                 draw: { text-blend-order: { font: { size: 12px, stroke: { width: 2 } } } }
             building_labels-z18:
                 filter: { $zoom: [18,19] }
-                draw: { text-blend-order: { font: { size: 10px, weight: 600, stroke: { width: 3 } } } }
+                draw: { text-blend-order: { font: { size: 10px, weight: 500, stroke: { width: 1 } } } }
             building_labels-z20-up:
                 filter: { $zoom: { min: 20 } }
-                draw: { text-blend-order: { font: { size: 14px, weight: 600, stroke: { width: 3 }  } } }
+                draw: { text-blend-order: { font: { size: 14px, weight: 500, stroke: { width: 1 }  } } }
             building-labels-z16:
                 filter: function() { if( $zoom == 16 && feature.name.length > 20 ) { return true; } else { return false; } }
                 draw:


### PR DESCRIPTION
This pull request modifies the cinnabar basemap style to display house numbers, building names and bus stops on the base map. Resolves issue #162.

Since there are quests to add house numbers and details about bus stops, it seems reasonable to me that these details should be visible on the base map.  Additionally, it may make orientation easier.  However, it does involve modifying the default cinnabar style, which may make updating to new upstream releases, while maintaining these changes, more difficult.

There are a couple of possible issues with these changes:
1. A possible bug in tangram-es prevents '\n' being interpreted as a line break (it works in Tangram Play on the web, but not in the app), so I've opted to display building name in preference to house number in cases where both of these exist.  This is an assumption on my part that building name tends to be more important than building number.
2. These items are only displayed from z18 onwards.  This may or may not be an appropriate zoom level to begin displaying at.
3. Quests will prevent the items from being displayed. For example, the quest marker for a bus stop quest will be displayed, but the bus stop symbol at that particular location won't.  This might not be a bad thing, however.
4. There will be a delay between submitting quest answers (for house numbers, at least) and the information being visible on the basemap due to mapzen not immediately updating their tiles. 

Screenshots:
Before:
![screenshot_2017-05-26-12-42-53](https://cloud.githubusercontent.com/assets/13661397/26564313/5be43e36-44d7-11e7-9eeb-23bf17a97841.png)

After:
![screenshot_20170527-004627](https://cloud.githubusercontent.com/assets/13661397/26564370/da601b90-44d7-11e7-9ea3-b140e7b6ba3b.png)
