### PR TITLE
better defaults for Poland

### DIFF
--- a/app/src/main/assets/countryInfos/PL.yml
+++ b/app/src/main/assets/countryInfos/PL.yml
@@ -1,1 +1,4 @@
 officialLanguages: [pl]
+# order based on http://taginfo.openstreetmap.pl/tags/leisure=pitch#combinations and http://taginfo.openstreetmap.pl/keys/sport#values
+popularSports: [soccer, basketball, tennis, volleyball, beachvolleyball, skateboard, table_tennis, handball, equestrian, gymnastics, shooting, baseball, athletics, rugby, golf, archery, netball, ice_hockey, field_hockey, american_football, cricket, badminton, bowls, boules, australian_football, canadian_football]
+regularShoppingDays: 5


### PR DESCRIPTION
Note that PR merges into dev branch, not master

order of sports is based on http://taginfo.openstreetmap.pl/tags/leisure=pitch#combinations , http://taginfo.openstreetmap.pl/keys/sport#values personal experience for values with low popularity and available sports in https://github.com/westnordost/StreetComplete/blob/c59c774e179d51d9210cc37f4d35b0b0cdb9dc4e/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.java#L18

Main problem with the current sport order is baseball on the third position what makes no sense in Poland.

regularShoppingDays: 5 is based on observation that most objects has special opening hours for Sunday and Saturday so on filling opening hours the first step is typically to unmark Saturday to set weekday opening hours.

note: this PR is untested