### PR TITLE
Skip access=private toilets for toilets_fee quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/toilets_fee/AddToiletsFee.java
@@ -22,7 +22,7 @@ public class AddToiletsFee extends SimpleOverpassQuestType
 	@Override
 	protected String getTagFilters()
 	{
-		return "nodes, ways with amenity=toilets and !fee";
+		return "nodes, ways with amenity=toilets and access!=private and !fee";
 	}
 
 	@Override


### PR DESCRIPTION
Some toilets in OSM have an access=private tag. 

They could be [indoor microtagging](http://www.openstreetmap.org/way/305970539), available for [renting with a bbq hut](http://www.openstreetmap.org/node/301485710) or part of [a camping site](http://www.openstreetmap.org/node/2240025881#map=18/51.07365/7.56255).