### PR TITLE
Display quests on the map in order of importance

### DIFF
--- a/app/src/main/assets/streetcomplete.yaml
+++ b/app/src/main/assets/streetcomplete.yaml
@@ -67,7 +67,7 @@ layers:
         draw:
             quest-icons:
                 interactive: true
-                priority: 0
+                priority: function() { return feature.importance }
                 size: 64px
                 sprite: function() { return feature.kind }
                 sprite_default: quest

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
@@ -365,6 +365,10 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 			geoJson.append(MARKER_QUEST_ID);
 			geoJson.append("\":\"");
 			geoJson.append(quest.getId());
+			geoJson.append("\",\"");
+			geoJson.append("importance");
+			geoJson.append("\":\"");
+			geoJson.append(quest.getType().importance());
 			geoJson.append("\"}}");
 		}
 		geoJson.append("]}");


### PR DESCRIPTION
This is a fix for #294.

It displays quests according to their priority as determined by their QuestImportance property.  The quest importance is added to the generated geojson and retrieved by the stylesheet when adding the quests to the map.  Lower numbers are displayed on top of higher numbers.  Currently, the quests have the following importance:

- Bike Parking Capacity: Minor: 50
- Building Levels: Minor: 50
- Bus Stop Shelter: Minor: 50
- Housenumber: Major: 10
- Note Discussion: Note: 0
- Add Opening Hours: Minor: 50 
- Place Name (Not active): Major: 10
- Road Name: Warning: 5
- Road Surface: Major: 10
- Roof Shape: Minor: 50
- Sport: Major: 10
- Tactile Paving: Minor: 50
- Toilets Fee: Minor: 50

Available ranks are Note (0), Error (1), Warning (5), Major (10), Minor (50), Extra (100), Insignificant (200)