### PR TITLE
warn if mapzenApiKey is undefined

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,3 +101,10 @@ dependencies {
     compile 'com.google.guava:guava:20.0'
 
 }
+
+gradle.buildFinished { buildResult ->
+    if (!hasProperty('mapzenApiKey'))
+    {
+        println 'mapzenApiKey property is undefined. Map performance will be very poor.'
+    }
+}


### PR DESCRIPTION
I think that it would be a good idea to document that for acceptable performance mapzen requires providing API key.

The best thing would be to add entry in Adroid Studio event log (or change "Gradle build finished in 22s 363ms" to something like "20:14	Gradle build finished with warnings in 22s 363ms"), but I am not sure how it can be done.

I thought about outright failing build without defined api key as that would be impossible to not notice, but given that code has explicit handling for situation with missing key it seems to be supposed to be acceptable.