### PR TITLE
Make one letter in the middle of a sentence lowercase

### DIFF
--- a/app/src/main/res/raw/credits_translations.yml
+++ b/app/src/main/res/raw/credits_translations.yml
@@ -13,7 +13,7 @@
 - Polski: Tomasz Maciejewski, Anett Sichla i wiele więcej
 - Português (BR): Patrick Montenegro, Alexandre de Menezes
 - Português (PT): Nuno Caldeira, APIRES
-- Русский: Anton Shestakov, zetx16 И многие другие
+- Русский: Anton Shestakov, zetx16 и многие другие
 - Shqip: Arianit Dobroshi
 - Suomi: Jimi Viita:aho
 - Svenska: Erik, Henrik Gripenberg, Albin Falsen


### PR DESCRIPTION
No reason for it to be uppercase.

(edited on github, it adds a newline)