### PR TITLE
Display road name in quest title

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_surface/AddRoadSurfaceForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_surface/AddRoadSurfaceForm.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 
 import java.util.Arrays;
 
+import de.westnordost.osmapi.map.data.OsmElement;
 import de.westnordost.streetcomplete.R;
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment;
 import de.westnordost.streetcomplete.view.GroupedImageSelectAdapter;
@@ -46,7 +47,7 @@ public class AddRoadSurfaceForm extends AbstractQuestFormAnswerFragment
 	{
 		View view = super.onCreateView(inflater, container, savedInstanceState);
 
-		setTitle(R.string.quest_streetSurface_title);
+		setTitle();
 
 		View contentView = setContentView(R.layout.quest_street_surface);
 
@@ -56,6 +57,20 @@ public class AddRoadSurfaceForm extends AbstractQuestFormAnswerFragment
 		surfaceSelect.setNestedScrollingEnabled(false);
 
 		return view;
+	}
+
+	private void setTitle()
+	{
+		OsmElement element = getOsmElement();
+		String name = element != null && element.getTags() != null ? element.getTags().get("name") : null;
+		if(name != null && !name.trim().isEmpty())
+		{
+			setTitle(R.string.quest_streetSurface_name_title, name);
+		}
+		else
+		{
+			setTitle(R.string.quest_streetSurface_title);
+		}
 	}
 
 	@Override protected void onClickOk()

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -174,6 +174,7 @@ Pour afficher la carte, les tuiles vectorielles sont extraites du &lt;a href=\"h
 
     <!-- Plus simple et plus court : "Quel est le revêtement de cette rue ?" -->
     <string name="quest_streetSurface_title">"Quel est le revêtement de cette rue ?"</string>
+    <string name="quest_streetSurface_name_title">"Quel est le revêtement de la rue « %s » ?"</string>
     <string name="quest_surface_description">"Sélectionner celui qui correspond le plus :"</string>
     <string name="quest_surface_value_paved">"Pavé (générique)"</string>
     <string name="quest_surface_value_unpaved">"Non pavé (générique)"</string>
@@ -297,5 +298,9 @@ L'information que vous entrez est directement ajoutée à OpenStreetMap sous vot
     <string name="quest_toiletsFee_title">"Ces toilettes sont-elles payantes ?"</string>
     <string name="quest_tactilePaving_title_bus">"Cet arrêt de bus a-t-il une surface podotactile ?"</string>
     <string name="quest_tactilePaving_title_crosswalk">"Ce passage piéton a-t-il une surface podotactile ?"</string>
+<string name="quest_source_dialog_title">"Confirmez-vous avoir vérifier cela sur place ?"</string>
     <string name="quest_tactilePaving_title_name_bus">"L’arrêt de bus « %s » a-t-il une surface podotactile ?"</string>
+<string name="quest_source_dialog_note">"Seules les informations relevées sur place peuvent être ajoutées."</string>
+<string name="quest_bicycleParkingCoveredStatus_title">"Ce parking à vélo est-il abrité (protégé de la pluie) ?"</string>
+<string name="dialog_session_dont_show_again">"Ne plus afficher pour cette session"</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -298,9 +298,9 @@ L'information que vous entrez est directement ajoutée à OpenStreetMap sous vot
     <string name="quest_toiletsFee_title">"Ces toilettes sont-elles payantes ?"</string>
     <string name="quest_tactilePaving_title_bus">"Cet arrêt de bus a-t-il une surface podotactile ?"</string>
     <string name="quest_tactilePaving_title_crosswalk">"Ce passage piéton a-t-il une surface podotactile ?"</string>
-<string name="quest_source_dialog_title">"Confirmez-vous avoir vérifier cela sur place ?"</string>
+    <string name="quest_source_dialog_title">"Confirmez-vous avoir vérifier cela sur place ?"</string>
     <string name="quest_tactilePaving_title_name_bus">"L’arrêt de bus « %s » a-t-il une surface podotactile ?"</string>
-<string name="quest_source_dialog_note">"Seules les informations relevées sur place peuvent être ajoutées."</string>
-<string name="quest_bicycleParkingCoveredStatus_title">"Ce parking à vélo est-il abrité (protégé de la pluie) ?"</string>
-<string name="dialog_session_dont_show_again">"Ne plus afficher pour cette session"</string>
+    <string name="quest_source_dialog_note">"Seules les informations relevées sur place peuvent être ajoutées."</string>
+    <string name="quest_bicycleParkingCoveredStatus_title">"Ce parking à vélo est-il abrité (protégé de la pluie) ?"</string>
+    <string name="dialog_session_dont_show_again">"Ne plus afficher pour cette session"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,7 @@ To display the map, vector tiles are retrieved from the &lt;a href=\"https://map
     <string name="autosync_only_on_wifi">"Only on Wifi"</string>
     <string name="autosync_off">"Off"</string>
     <string name="quest_streetSurface_title">"What surface does this piece of road have?"</string>
+    <string name="quest_streetSurface_name_title">"What surface does the road \"%s\" have?"</string>
     <string name="quest_surface_description">"Select the most specific one that fits:"</string>
     <string name="quest_surface_value_paved">"Paved (generic)"</string>
     <string name="quest_surface_value_unpaved">"Unpaved (generic)"</string>


### PR DESCRIPTION
Quite simple fix but very useful (especially in big cities) !
With this fix, you just need to look at the road name on the street sign to be sure that you add road surface to the corrresponding one.

![2017-06-24 00_49_42-screenshot_20170624-000438](https://user-images.githubusercontent.com/6597721/27502833-5b8f66aa-5877-11e7-9dca-83a89b9bf030.png)
