### PR TITLE
Replace Bus stops with bus stations in public transport wheelchair quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelChairAccessPublicTransport.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelChairAccessPublicTransport.java
@@ -18,8 +18,8 @@ public class AddWheelChairAccessPublicTransport extends SimpleOverpassQuestType
 
 	@Override protected String getTagFilters()
 	{
-		return " nodes, ways, relations with public_transport=platform or " +
-				"(highway=bus_stop and public_transport!=stop_position) or " +
+		return " nodes, ways, relations with " +
+				" amenity = bus_station or " +
 				" railway ~ station|subway_entrance" +
 				" and !wheelchair";
 	}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransportForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransportForm.java
@@ -22,19 +22,14 @@ public class AddWheelchairAccessPublicTransportForm extends WheelchairAccessAnsw
 	{
 		OsmElement element = getOsmElement();
 		String name = element != null && element.getTags() != null ? element.getTags().get("name") : null;
-		String type = element.getTags().get("highway");
+		String type = element.getTags().get("amenity");
 		if (type == null) {type = element.getTags().get("railway");}
-		if (type == null) {type = element.getTags().get("public_transport");}
 		String typeString;
 
 		switch (type)
 		{
-			case "bus_stop":
-				typeString = getString(R.string.element_bus_stop);
-				break;
-			case "platform":
-				typeString = getString(R.string.element_platform);
-				break;
+			case "bus_station":
+				typeString = getString(R.string.element_bus_station);
 			case "station":
 				typeString = getString(R.string.element_railway_station);
 				break;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,11 +285,10 @@ The info you enter is then directly added to the OpenStreetMap in your name, wit
     <string name="quest_wheelchairAccess_type_title">Is this %s wheelchair accessible?</string>
     <string name="quest_wheelchairAccess_name_title">Is “%s” wheelchair accessible?</string>
     <string name="quest_wheelchairAccess_name_type_title">Is the %1$s “%2$s” wheelchair accessible?</string>
+    <string name="element_bus_station">bus station</string>
     <string name="element_subway_entrance">subway entrance</string>
     <string name="element_railway_station">railway station</string>
-    <string name="element_platform">platform</string>
     <string name="element_location">location</string>
-    <string name="element_bus_stop">bus stop</string>
     <string name="quest_wheelchairAccess_limited">Partially</string>
     <string name="quest_wheelchair_limited_description_business">Partially means that there is no more than a single step to access the business and that most rooms inside are wheelchair accessible.</string>
     <string name="quest_wheelchair_limited_description_public_transport">Partially means that there is no more than a single step to access it.</string>


### PR DESCRIPTION
This pull request removes bus and rail platforms from the public transport wheelchair quest (public_transport=platform & highway = bus_stop) and adds bus stations instead (amenity = bus_station) (Issue #346 )

One potential issue is that people using the development branch may experience crashes if they try to enter a bus stop quest that was downloaded using the last revision, with this revision.  Clearing the quest cache and re-downloading quests will resolve this.  It does not affect the production version as this quest has never gone live in that version.  Because of this, I would suggest that this should not be considered a problem. 