### PR TITLE
Fix for #375: Only substitute the location's name in strings

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransportForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessPublicTransportForm.java
@@ -24,27 +24,38 @@ public class AddWheelchairAccessPublicTransportForm extends WheelchairAccessAnsw
 		String name = element != null && element.getTags() != null ? element.getTags().get("name") : null;
 		String type = element.getTags().get("amenity");
 		if (type == null) {type = element.getTags().get("railway");}
-		String typeString;
-
-		switch (type)
-		{
-			case "bus_station":
-				typeString = getString(R.string.element_bus_station);
-			case "station":
-				typeString = getString(R.string.element_railway_station);
-				break;
-			case "subway_entrance":
-				typeString = getString(R.string.element_subway_entrance);
-				break;
-			default:
-				typeString = getString(R.string.element_location);
-		}
 
 		if(name != null && !name.trim().isEmpty())
 		{
-			setTitle(R.string.quest_wheelchairAccess_name_type_title, typeString, name);
+			switch (type)
+			{
+				case "bus_station":
+					setTitle(R.string.quest_wheelchairAccess_bus_station_name_title, name);
+					break;
+				case "station":
+					setTitle(R.string.quest_wheelchairAccess_railway_station_name_title, name);
+					break;
+				case "subway_entrance":
+					setTitle(R.string.quest_wheelchairAccess_subway_entrance_name_title, name);
+					break;
+				default:
+					setTitle(R.string.quest_wheelchairAccess_location_name_title, name);
+			}
 		} else {
-			setTitle(R.string.quest_wheelchairAccess_type_title, typeString);
+			switch (type)
+			{
+				case "bus_station":
+					setTitle(R.string.quest_wheelchairAccess_bus_station_title);
+					break;
+				case "station":
+					setTitle(R.string.quest_wheelchairAccess_railway_station_title);
+					break;
+				case "subway_entrance":
+					setTitle(R.string.quest_wheelchairAccess_subway_entrance_title);
+					break;
+				default:
+					setTitle(R.string.quest_wheelchairAccess_location_title);
+			}
 		}
 	}
 }

--- a/app/src/main/res/layout/quest_wheelchair_business_explanation.xml
+++ b/app/src/main/res/layout/quest_wheelchair_business_explanation.xml
@@ -5,7 +5,7 @@
         android:id="@+id/description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/quest_wheelchair_limited_description_business"
+        android:text="@string/quest_wheelchairAccess_limited_description_business"
         android:labelFor="@+id/nameInput"/>
 
 </merge>

--- a/app/src/main/res/layout/quest_wheelchair_public_transport_explanation.xml
+++ b/app/src/main/res/layout/quest_wheelchair_public_transport_explanation.xml
@@ -5,7 +5,7 @@
         android:id="@+id/description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/quest_wheelchair_limited_description_public_transport"
+        android:text="@string/quest_wheelchairAccess_limited_description_public_transport"
         android:labelFor="@+id/nameInput"/>
 
 </merge>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,14 +282,16 @@ The info you enter is then directly added to the OpenStreetMap in your name, wit
     <string name="quest_sport_gaelic_games">Gaelic Games</string>
     <string name="quest_sport_sepak_takraw">Sepak Takraw</string>
     <string name="quest_sport_skating">Skating</string>
-    <string name="quest_wheelchairAccess_type_title">Is this %s wheelchair accessible?</string>
     <string name="quest_wheelchairAccess_name_title">Is “%s” wheelchair accessible?</string>
-    <string name="quest_wheelchairAccess_name_type_title">Is the %1$s “%2$s” wheelchair accessible?</string>
-    <string name="element_bus_station">bus station</string>
-    <string name="element_subway_entrance">subway entrance</string>
-    <string name="element_railway_station">railway station</string>
-    <string name="element_location">location</string>
+    <string name="quest_wheelchairAccess_bus_station_title">Is this bus station wheelchair accessible?</string>
+    <string name="quest_wheelchairAccess_subway_entrance_title">Is this subway entrance wheelchair accessible?</string>
+    <string name="quest_wheelchairAccess_railway_station_title">Is this railway station wheelchair accessible?</string>
+    <string name="quest_wheelchairAccess_location_title">Is this location wheelchair accessible?</string>
+    <string name="quest_wheelchairAccess_bus_station_name_title">Is the bus station “%s” wheelchair accessible?</string>
+    <string name="quest_wheelchairAccess_subway_entrance_name_title">Is the subway entrance “%s” wheelchair accessible?</string>
+    <string name="quest_wheelchairAccess_railway_station_name_title">Is the railway station “%s” wheelchair accessible?</string>
+    <string name="quest_wheelchairAccess_location_name_title">Is the location “%s” wheelchair accessible?</string>
     <string name="quest_wheelchairAccess_limited">Partially</string>
-    <string name="quest_wheelchair_limited_description_business">Partially means that there is no more than a single step to access the business and that most rooms inside are wheelchair accessible.</string>
-    <string name="quest_wheelchair_limited_description_public_transport">Partially means that there is no more than a single step to access it.</string>
+    <string name="quest_wheelchairAccess_limited_description_business">Partially means that there is no more than a single step to access the business and that most rooms inside are wheelchair accessible.</string>
+    <string name="quest_wheelchairAccess_limited_description_public_transport">Partially means that there is no more than a single step to access it.</string>
 </resources>


### PR DESCRIPTION
This pull request fixes #375.

The only substitutions made now in the wheelchair quest are to add the location's name to the string, where that exists.