### PR TITLE
Solve or create note with image

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteDialog.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteDialog.java
@@ -18,6 +18,7 @@ import android.provider.OpenableColumns;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.widget.Button;
 import android.widget.EditText;
 
@@ -186,10 +187,10 @@ public class LeaveNoteDialog extends DialogFragment
 	private class ImageUploadHelper extends AsyncTask<Uri, String, String>
 	{
 
-		private Context mContext;
+		private Context context;
 
-		ImageUploadHelper (Context context){
-			mContext = context;
+		ImageUploadHelper (Context Context){
+			context = Context;
 		}
 
 		private ProgressDialog LoadingDialog;
@@ -206,8 +207,8 @@ public class LeaveNoteDialog extends DialogFragment
 
 		@Override
 		protected String doInBackground(Uri... imageUri) {
-			if (!isConnectedToInternet(mContext)) {
-				new AlertDialogBuilder(mContext)
+			if (!isConnectedToInternet(context)) {
+				new AlertDialogBuilder(context)
 						.setMessage(R.string.connection_error)
 						.setPositiveButton(android.R.string.ok, null)
 						.setNegativeButton(android.R.string.cancel, null)
@@ -227,7 +228,7 @@ public class LeaveNoteDialog extends DialogFragment
 			InputStream stream = null;
 			DataOutputStream request = null;
 			try {
-				if (isConnectedToInternet(mContext)) {
+				if (isConnectedToInternet(context)) {
 
 					String crlf = "\r\n";
 					String hyphens = "--";
@@ -278,7 +279,7 @@ public class LeaveNoteDialog extends DialogFragment
 					request_size += keepExif.length();
 
 					String[] proj = {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE};
-					Cursor cursor = mContext.getContentResolver().query(imageUri[0], proj, null, null, null);
+					Cursor cursor = context.getContentResolver().query(imageUri[0], proj, null, null, null);
 					String fileName = null;
 					long size = 0;
 					if (cursor != null && cursor.moveToFirst()) {
@@ -312,7 +313,7 @@ public class LeaveNoteDialog extends DialogFragment
 					request.flush();
 					InputStream streamIn = null;
 					try {
-						streamIn = mContext.getContentResolver().openInputStream(imageUri[0]);
+						streamIn = context.getContentResolver().openInputStream(imageUri[0]);
 					} catch (Exception e) {
 						e.printStackTrace();
 						LoadingDialog.dismiss();
@@ -396,8 +397,17 @@ public class LeaveNoteDialog extends DialogFragment
 		}
 
 		protected void onPostExecute(String result) {
-			noteInput.setText(result + "\n");
 			LoadingDialog.dismiss();
+			if (!result.equals("https://lut.im/")){
+				noteInput.setText(result);
+			}
+			else
+			{
+				new AlertDialogBuilder(context)
+						.setMessage(R.string.image_upload_error)
+						.setPositiveButton(android.R.string.ok, null)
+						.show();
+			}
 		}
 
 		private boolean isConnectedToInternet(Context context) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteDialog.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LeaveNoteDialog.java
@@ -1,17 +1,42 @@
 package de.westnordost.streetcomplete.quests;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.DialogFragment;
+import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.OpenableColumns;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Window;
 import android.widget.Button;
 import android.widget.EditText;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import de.westnordost.streetcomplete.R;
+import de.westnordost.streetcomplete.view.dialogs.AlertDialogBuilder;
+
+import static android.app.Activity.RESULT_OK;
 
 public class LeaveNoteDialog extends DialogFragment
 {
@@ -52,6 +77,25 @@ public class LeaveNoteDialog extends DialogFragment
 			public void onClick(View v)
 			{
 				onClickOk();
+			}
+		});
+		Button buttonUploadImage = (Button) view.findViewById(R.id.buttonUploadImage);
+		buttonUploadImage.setOnClickListener(new View.OnClickListener()
+		{
+			@Override public void onClick(View v)
+			{
+				if (Build.VERSION.SDK_INT <19){
+					Intent intent = new Intent();
+					intent.setType("image/*");
+					intent.setAction(Intent.ACTION_GET_CONTENT);
+					startActivityForResult(Intent.createChooser(intent, getResources().getString(R.string.select_image)), 1);
+				} else {
+					Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+					intent.addCategory(Intent.CATEGORY_OPENABLE);
+					intent.setType("image/*");
+					startActivityForResult(intent, 2);
+				}
+
 			}
 		});
 
@@ -99,5 +143,274 @@ public class LeaveNoteDialog extends DialogFragment
 	{
 		questAnswerComponent.onSkippedQuest();
 		dismiss();
+	}
+
+	@Override
+	@SuppressLint("NewApi")
+	public void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
+
+		if (resultCode == RESULT_OK && data != null && data.getData() != null) {
+
+			Uri uri = null;
+
+			if (requestCode == 1)
+			{
+				uri = data.getData();
+			}
+			else if (requestCode == 2)
+			{
+				uri = data.getData();
+				final int takeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION;
+				// Check for the freshest data.
+				getActivity().getContentResolver().takePersistableUriPermission(uri, takeFlags);
+			}
+
+			final Uri finalUri = uri;
+
+			new AlertDialogBuilder(getContext())
+					.setMessage(R.string.confirmation_publish_image)
+					.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener()
+					{
+						@Override public void onClick(DialogInterface dialog, int which)
+						{
+							new ImageUploadHelper(getContext()).execute(finalUri);
+						}
+					})
+					.setNegativeButton(android.R.string.cancel, null)
+					.show();
+
+		}
+	}
+
+	private class ImageUploadHelper extends AsyncTask<Uri, String, String>
+	{
+
+		private Context mContext;
+
+		ImageUploadHelper (Context context){
+			mContext = context;
+		}
+
+		private ProgressDialog LoadingDialog;
+
+		@Override
+		protected void onPreExecute(){
+			super.onPreExecute();
+			LoadingDialog = new ProgressDialog(getContext());
+			LoadingDialog.setMessage(getResources().getString(R.string.publishing_image));
+			LoadingDialog.setIndeterminate(true);
+			LoadingDialog.setCancelable(false);
+			LoadingDialog.show();
+		}
+
+		@Override
+		protected String doInBackground(Uri... imageUri) {
+			if (!isConnectedToInternet(mContext)) {
+				new AlertDialogBuilder(mContext)
+						.setMessage(R.string.connection_error)
+						.setPositiveButton(android.R.string.ok, null)
+						.setNegativeButton(android.R.string.cancel, null)
+						.show();
+				return null;
+			}
+
+			URL url = null;
+			String urlToImage = "https://lut.im/";
+			try {
+				url = new URL("https://lut.im/");
+			} catch (MalformedURLException e1) {
+				e1.printStackTrace();
+			}
+
+			HttpURLConnection conn = null;
+			InputStream stream = null;
+			DataOutputStream request = null;
+			try {
+				if (isConnectedToInternet(mContext)) {
+
+					String crlf = "\r\n";
+					String hyphens = "--";
+					String boundary = "------------------------dd8a045fcc22b35c";
+					//check if there is a HTTP 301 Error
+					if (url != null) {
+						conn = (HttpURLConnection) url.openConnection();
+					}
+					String location = conn.getHeaderField("Location");
+					if (location != null) {
+						//if there is follow the new destination
+						url = new URL(location);
+					}
+					conn = (HttpURLConnection) url.openConnection();
+					//prepare the connection for upload
+					conn.setRequestMethod("POST");
+					conn.setUseCaches(false);
+					conn.setDoInput(true);
+					conn.setDoOutput(true);
+
+					conn.setRequestProperty("User-Agent", "StreetComplete");
+
+					conn.setRequestProperty("Expect", "100-continue");
+					conn.setRequestProperty("Accept", "*/*");
+					conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+					int request_size = 0;
+
+					//ask for JSON answer
+					String answer = hyphens + boundary + crlf;
+					answer += "Content-Disposition: form-data; name=\"format\"" + crlf;
+					answer += crlf;
+					answer += "json" + crlf;
+					request_size += answer.length();
+
+					//ask for storage duration
+					String duration = hyphens + boundary + crlf;
+					duration += "Content-Disposition: form-data; name=\"delete-day\"" + crlf;
+					duration += crlf;
+					duration += 0 + crlf;
+					request_size += duration.length();
+
+					//keep EXIF tags
+					String keepExif = hyphens + boundary + crlf;
+					keepExif += "Content-Disposition: form-data; name=\"keep-exif\"" + crlf;
+					keepExif += crlf;
+					keepExif += 1 + crlf;
+					request_size += keepExif.length();
+
+					String[] proj = {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE};
+					Cursor cursor = mContext.getContentResolver().query(imageUri[0], proj, null, null, null);
+					String fileName = null;
+					long size = 0;
+					if (cursor != null && cursor.moveToFirst()) {
+						fileName = cursor.getString(0);
+						size = cursor.getLong(1);
+						cursor.close();
+					}
+
+					//setup filename and say that octets follow
+					String outputInformations = hyphens + boundary + crlf;
+					outputInformations += "Content-Disposition: form-data; name=\"file\"; filename=\"" + fileName + "\"" + crlf;
+					outputInformations += "Content-Type: application/octet-stream" + crlf;
+					outputInformations += crlf;
+					request_size += outputInformations.length();
+
+					request_size += size;
+
+					//finish the format http post packet
+					String endHttp = crlf;
+					endHttp += hyphens + boundary + hyphens + crlf;
+					request_size += endHttp.length();
+
+					conn.setFixedLengthStreamingMode(request_size);
+
+					//write data
+					request = new DataOutputStream(conn.getOutputStream());
+					request.writeBytes(answer);
+					request.writeBytes(duration);
+					request.writeBytes(keepExif);
+					request.writeBytes(outputInformations);
+					request.flush();
+					InputStream streamIn = null;
+					try {
+						streamIn = mContext.getContentResolver().openInputStream(imageUri[0]);
+					} catch (Exception e) {
+						e.printStackTrace();
+						LoadingDialog.dismiss();
+					}
+					//read data from the file and write it
+					if (streamIn != null) {
+						int readed = 0;
+						int blockSize = 1024;
+						byte[] buffer = new byte[blockSize];
+						while (readed != -1) {
+							try {
+								readed = streamIn.read(buffer);
+								if (readed != -1) {
+									request.write(buffer, 0, readed);
+								}
+							} catch (IOException e) {
+								e.printStackTrace();
+								readed = -1;
+								LoadingDialog.dismiss();
+							}
+						}
+					}
+					request.writeBytes(endHttp);
+					request.flush();
+
+					//get answer
+					stream = conn.getInputStream();
+				}
+			} catch (IOException e1) {
+				if (conn != null) {
+					stream = conn.getErrorStream();
+				} else {
+					e1.printStackTrace();
+				}
+			}
+
+			if (stream != null) {
+				//prepare JSON reading
+				InputStreamReader isr = new InputStreamReader(stream);
+				BufferedReader br = new BufferedReader(isr);
+				boolean isReading = true;
+				String JSONData;
+				String jsonStr = "";
+				//get all data in a String
+				do {
+					try {
+						JSONData = br.readLine();
+						if (JSONData != null)
+							jsonStr += JSONData;
+						else
+							isReading = false;
+					} catch (IOException e) {
+						e.printStackTrace();
+						isReading = false;
+					}
+				} while (isReading);
+				//parse JSON answer
+				try {
+					if (request != null)
+						request.close();
+					stream.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+				try {
+					// Parse the JSON to a JSONObject
+					JSONObject rootObject = new JSONObject(jsonStr);
+					// Get msg (root) element
+					// is there an error?
+					if (rootObject.has("msg")) {
+						//retrieve useful data
+						JSONObject msg = rootObject.getJSONObject("msg");
+						String hashOutput = msg.getString("short");
+						urlToImage += hashOutput;
+					}
+				} catch (JSONException e) {
+					e.printStackTrace();
+				}
+			}
+			return urlToImage;
+		}
+
+		protected void onPostExecute(String result) {
+			noteInput.setText(result + "\n");
+			LoadingDialog.dismiss();
+		}
+
+		private boolean isConnectedToInternet(Context context) {
+			//verify the connectivity
+			ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+			NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
+			if (networkInfo != null) {
+				NetworkInfo.State networkState = networkInfo.getState();
+				if (networkState.equals(NetworkInfo.State.CONNECTED)) {
+					return true;
+				}
+			}
+			return false;
+		}
 	}
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.java
@@ -1,6 +1,18 @@
 package de.westnordost.streetcomplete.quests.note_discussion;
 
+import android.annotation.SuppressLint;
+import android.app.ProgressDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.OpenableColumns;
 import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -12,6 +24,17 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Date;
 import javax.inject.Inject;
 
@@ -22,7 +45,9 @@ import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment;
 import de.westnordost.streetcomplete.util.InlineAsyncTask;
 import de.westnordost.osmapi.notes.Note;
 import de.westnordost.osmapi.notes.NoteComment;
+import de.westnordost.streetcomplete.view.dialogs.AlertDialogBuilder;
 
+import static android.app.Activity.RESULT_OK;
 import static android.text.format.DateUtils.MINUTE_IN_MILLIS;
 
 public class NoteDiscussionForm extends AbstractQuestAnswerFragment
@@ -67,6 +92,25 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 				skipQuest();
 			}
 		});
+		Button buttonUploadImage = (Button) buttonPanel.findViewById(R.id.buttonUploadImage);
+		buttonUploadImage.setOnClickListener(new View.OnClickListener()
+		{
+			@Override public void onClick(View v)
+			{
+				if (Build.VERSION.SDK_INT <19){
+					Intent intent = new Intent();
+					intent.setType("image/*");
+					intent.setAction(Intent.ACTION_GET_CONTENT);
+					startActivityForResult(Intent.createChooser(intent, getResources().getString(R.string.select_image)), 1);
+				} else {
+					Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+					intent.addCategory(Intent.CATEGORY_OPENABLE);
+					intent.setType("image/*");
+					startActivityForResult(intent, 2);
+				}
+
+			}
+		});
 
 		noteInput = (EditText) contentView.findViewById(R.id.noteInput);
 		noteDiscussion = (LinearLayout) contentView.findViewById(R.id.noteDiscussion);
@@ -95,6 +139,44 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 		}.execute();
 
 		return view;
+	}
+
+	@Override
+	@SuppressLint("NewApi")
+	public void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
+
+		if (resultCode == RESULT_OK && data != null && data.getData() != null) {
+
+			Uri uri = null;
+
+			if (requestCode == 1)
+			{
+				uri = data.getData();
+			}
+			else if (requestCode == 2)
+			{
+				uri = data.getData();
+				final int takeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION;
+				// Check for the freshest data.
+				getActivity().getContentResolver().takePersistableUriPermission(uri, takeFlags);
+			}
+
+			final Uri finalUri = uri;
+
+			new AlertDialogBuilder(getContext())
+					.setMessage(R.string.confirmation_publish_image)
+					.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener()
+					{
+						@Override public void onClick(DialogInterface dialog, int which)
+						{
+							new ImageUploadHelper(getContext()).execute(finalUri);
+						}
+					})
+					.setNegativeButton(android.R.string.cancel, null)
+					.show();
+
+		}
 	}
 
 	private void inflateNoteDiscussion(Note note)
@@ -171,4 +253,226 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 		return !noteInput.getText().toString().trim().isEmpty();
 	}
 
+	private class ImageUploadHelper extends AsyncTask<Uri, String, String>
+	{
+
+		private Context mContext;
+
+		ImageUploadHelper (Context context){
+			mContext = context;
+		}
+
+		private ProgressDialog LoadingDialog;
+
+		@Override
+		protected void onPreExecute(){
+			super.onPreExecute();
+			LoadingDialog = new ProgressDialog(getContext());
+			LoadingDialog.setMessage(getResources().getString(R.string.publishing_image));
+			LoadingDialog.setIndeterminate(true);
+			LoadingDialog.setCancelable(false);
+			LoadingDialog.show();
+		}
+
+		@Override
+		protected String doInBackground(Uri... imageUri) {
+			if (!isConnectedToInternet(mContext)) {
+				new AlertDialogBuilder(mContext)
+						.setMessage(R.string.connection_error)
+						.setPositiveButton(android.R.string.ok, null)
+						.setNegativeButton(android.R.string.cancel, null)
+						.show();
+				return null;
+			}
+
+			URL url = null;
+			String urlToImage = "https://lut.im/";
+			try {
+				url = new URL("https://lut.im/");
+			} catch (MalformedURLException e1) {
+				e1.printStackTrace();
+			}
+
+			HttpURLConnection conn = null;
+			InputStream stream = null;
+			DataOutputStream request = null;
+			try {
+				if (isConnectedToInternet(mContext)) {
+
+					String crlf = "\r\n";
+					String hyphens = "--";
+					String boundary = "------------------------dd8a045fcc22b35c";
+					//check if there is a HTTP 301 Error
+					if (url != null) {
+						conn = (HttpURLConnection) url.openConnection();
+					}
+					String location = conn.getHeaderField("Location");
+					if (location != null) {
+						//if there is follow the new destination
+						url = new URL(location);
+					}
+					conn = (HttpURLConnection) url.openConnection();
+					//prepare the connection for upload
+					conn.setRequestMethod("POST");
+					conn.setUseCaches(false);
+					conn.setDoInput(true);
+					conn.setDoOutput(true);
+
+					conn.setRequestProperty("User-Agent", "StreetComplete");
+
+					conn.setRequestProperty("Expect", "100-continue");
+					conn.setRequestProperty("Accept", "*/*");
+					conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+					int request_size = 0;
+
+					//ask for JSON answer
+					String answer = hyphens + boundary + crlf;
+					answer += "Content-Disposition: form-data; name=\"format\"" + crlf;
+					answer += crlf;
+					answer += "json" + crlf;
+					request_size += answer.length();
+
+					//ask for storage duration
+					String duration = hyphens + boundary + crlf;
+					duration += "Content-Disposition: form-data; name=\"delete-day\"" + crlf;
+					duration += crlf;
+					duration += 0 + crlf;
+					request_size += duration.length();
+
+					String[] proj = {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE};
+					Cursor cursor = mContext.getContentResolver().query(imageUri[0], proj, null, null, null);
+					String fileName = null;
+					long size = 0;
+					if (cursor != null && cursor.moveToFirst()) {
+						fileName = cursor.getString(0);
+						size = cursor.getLong(1);
+						cursor.close();
+					}
+
+					//setup filename and say that octets follow
+					String outputInformations = hyphens + boundary + crlf;
+					outputInformations += "Content-Disposition: form-data; name=\"file\"; filename=\"" + fileName + "\"" + crlf;
+					outputInformations += "Content-Type: application/octet-stream" + crlf;
+					outputInformations += crlf;
+					request_size += outputInformations.length();
+
+					request_size += size;
+
+					//finish the format http post packet
+					String endHttp = crlf;
+					endHttp += hyphens + boundary + hyphens + crlf;
+					request_size += endHttp.length();
+
+					conn.setFixedLengthStreamingMode(request_size);
+
+					//write data
+					request = new DataOutputStream(conn.getOutputStream());
+					request.writeBytes(answer);
+					request.writeBytes(duration);
+					request.writeBytes(outputInformations);
+					request.flush();
+					InputStream streamIn = null;
+					try {
+						streamIn = mContext.getContentResolver().openInputStream(imageUri[0]);
+					} catch (Exception e) {
+						e.printStackTrace();
+						LoadingDialog.dismiss();
+					}
+					//read data from the file and write it
+					if (streamIn != null) {
+						int readed = 0;
+						int blockSize = 1024;
+						byte[] buffer = new byte[blockSize];
+						while (readed != -1) {
+							try {
+								readed = streamIn.read(buffer);
+								if (readed != -1) {
+									request.write(buffer, 0, readed);
+								}
+							} catch (IOException e) {
+								e.printStackTrace();
+								readed = -1;
+								LoadingDialog.dismiss();
+							}
+						}
+					}
+					request.writeBytes(endHttp);
+					request.flush();
+
+					//get answer
+					stream = conn.getInputStream();
+				}
+			} catch (IOException e1) {
+				if (conn != null) {
+					stream = conn.getErrorStream();
+				} else {
+					e1.printStackTrace();
+				}
+			}
+
+			if (stream != null) {
+				//prepare JSON reading
+				InputStreamReader isr = new InputStreamReader(stream);
+				BufferedReader br = new BufferedReader(isr);
+				boolean isReading = true;
+				String JSONData;
+				String jsonStr = "";
+				//get all data in a String
+				do {
+					try {
+						JSONData = br.readLine();
+						if (JSONData != null)
+							jsonStr += JSONData;
+						else
+							isReading = false;
+					} catch (IOException e) {
+						e.printStackTrace();
+						isReading = false;
+					}
+				} while (isReading);
+				//parse JSON answer
+				try {
+					if (request != null)
+						request.close();
+					stream.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+				try {
+					// Parse the JSON to a JSONObject
+					JSONObject rootObject = new JSONObject(jsonStr);
+					// Get msg (root) element
+					// is there an error?
+					if (rootObject.has("msg")) {
+						//retrieve useful data
+						JSONObject msg = rootObject.getJSONObject("msg");
+						String hashOutput = msg.getString("short");
+						urlToImage += hashOutput;
+					}
+				} catch (JSONException e) {
+					e.printStackTrace();
+				}
+			}
+			return urlToImage;
+		}
+
+		protected void onPostExecute(String result) {
+			noteInput.setText(result);
+			LoadingDialog.dismiss();
+		}
+
+		private boolean isConnectedToInternet(Context context) {
+			//verify the connectivity
+			ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+			NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
+			if (networkInfo != null) {
+				NetworkInfo.State networkState = networkInfo.getState();
+				if (networkState.equals(NetworkInfo.State.CONNECTED)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.java
@@ -340,6 +340,13 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 					duration += 0 + crlf;
 					request_size += duration.length();
 
+					//keep EXIF tags
+					String keepExif = hyphens + boundary + crlf;
+					keepExif += "Content-Disposition: form-data; name=\"keep-exif\"" + crlf;
+					keepExif += crlf;
+					keepExif += 1 + crlf;
+					request_size += keepExif.length();
+
 					String[] proj = {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE};
 					Cursor cursor = mContext.getContentResolver().query(imageUri[0], proj, null, null, null);
 					String fileName = null;
@@ -369,7 +376,7 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 					//write data
 					request = new DataOutputStream(conn.getOutputStream());
 					request.writeBytes(answer);
-					request.writeBytes(duration);
+					request.writeBytes(keepExif);
 					request.writeBytes(outputInformations);
 					request.flush();
 					InputStream streamIn = null;
@@ -458,7 +465,7 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 		}
 
 		protected void onPostExecute(String result) {
-			noteInput.setText(result);
+			noteInput.setText(result + "\n");
 			LoadingDialog.dismiss();
 		}
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/NoteDiscussionForm.java
@@ -256,10 +256,10 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 	private class ImageUploadHelper extends AsyncTask<Uri, String, String>
 	{
 
-		private Context mContext;
+		private Context context;
 
-		ImageUploadHelper (Context context){
-			mContext = context;
+		ImageUploadHelper (Context Context){
+			context = Context;
 		}
 
 		private ProgressDialog LoadingDialog;
@@ -276,8 +276,8 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 
 		@Override
 		protected String doInBackground(Uri... imageUri) {
-			if (!isConnectedToInternet(mContext)) {
-				new AlertDialogBuilder(mContext)
+			if (!isConnectedToInternet(context)) {
+				new AlertDialogBuilder(context)
 						.setMessage(R.string.connection_error)
 						.setPositiveButton(android.R.string.ok, null)
 						.setNegativeButton(android.R.string.cancel, null)
@@ -297,7 +297,7 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 			InputStream stream = null;
 			DataOutputStream request = null;
 			try {
-				if (isConnectedToInternet(mContext)) {
+				if (isConnectedToInternet(context)) {
 
 					String crlf = "\r\n";
 					String hyphens = "--";
@@ -348,7 +348,7 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 					request_size += keepExif.length();
 
 					String[] proj = {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE};
-					Cursor cursor = mContext.getContentResolver().query(imageUri[0], proj, null, null, null);
+					Cursor cursor = context.getContentResolver().query(imageUri[0], proj, null, null, null);
 					String fileName = null;
 					long size = 0;
 					if (cursor != null && cursor.moveToFirst()) {
@@ -376,12 +376,13 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 					//write data
 					request = new DataOutputStream(conn.getOutputStream());
 					request.writeBytes(answer);
+					request.writeBytes(duration);
 					request.writeBytes(keepExif);
 					request.writeBytes(outputInformations);
 					request.flush();
 					InputStream streamIn = null;
 					try {
-						streamIn = mContext.getContentResolver().openInputStream(imageUri[0]);
+						streamIn = context.getContentResolver().openInputStream(imageUri[0]);
 					} catch (Exception e) {
 						e.printStackTrace();
 						LoadingDialog.dismiss();
@@ -465,8 +466,17 @@ public class NoteDiscussionForm extends AbstractQuestAnswerFragment
 		}
 
 		protected void onPostExecute(String result) {
-			noteInput.setText(result + "\n");
 			LoadingDialog.dismiss();
+			if (!result.equals("https://lut.im/")){
+				noteInput.setText(result);
+			}
+			else
+			{
+				new AlertDialogBuilder(context)
+						.setMessage(R.string.image_upload_error)
+						.setPositiveButton(android.R.string.ok, null)
+						.show();
+			}
 		}
 
 		private boolean isConnectedToInternet(Context context) {

--- a/app/src/main/res/layout/leave_note.xml
+++ b/app/src/main/res/layout/leave_note.xml
@@ -76,6 +76,14 @@
             android:text="@string/quest_leave_new_note_no"
             android:layout_height="wrap_content" />
         <Button
+            android:id="@+id/buttonUploadImage"
+            android:layout_width="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            style="?android:attr/buttonBarButtonStyle"
+            android:text="@string/upload_image"
+            android:layout_height="wrap_content" />
+        <Button
             android:id="@+id/buttonOk"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/quest_notediscussion_buttonbar.xml
+++ b/app/src/main/res/layout/quest_notediscussion_buttonbar.xml
@@ -10,6 +10,15 @@
         android:text="@string/quest_noteDiscussion_no" />
 
     <Button
+        android:id="@+id/buttonUploadImage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        style="?android:attr/buttonBarButtonStyle"
+        android:text="@string/upload_image"
+        />
+
+    <Button
         android:id="@+id/buttonOk"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -321,4 +321,9 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="credits_and_more">and more …</string>
     <string name="quest_maxspeed_answer_living_street">It is a living street</string>
     <string name="quest_maxspeed_answer_living_street_confirmation_title">So, there is a sign like this?</string>
+    <string name="upload_image">Upload image</string>
+    <string name="select_image">Select image</string>
+    <string name="connection_error">There is no connection at the moment. Please try again later!</string>
+    <string name="publishing_image">Publishing image. Please wait.</string>
+    <string name="confirmation_publish_image">Are you sure that you want to publish this image?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,4 +326,5 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="connection_error">There is no connection at the moment. Please try again later!</string>
     <string name="publishing_image">Publishing image. Please wait.</string>
     <string name="confirmation_publish_image">Are you sure that you want to publish this image?</string>
+    <string name="image_upload_error">There was an error while uploading the image. Please try again later!</string>
 </resources>


### PR DESCRIPTION
This PR adds a the possibility to upload an image if the user leaves a note or takes part in a note discussion. The image will be uploaded to https://lut.im after the user selected an image from the gallery. No credentials or a login is needed. If the image was uploaded successfully, a link to the image is displayed in the note input textbox, so that other users can easily access this image and hopefully solve the note. This feature was requested by many users in #90. I hope you like it 😄 

### Here are some screenshots:

### Take part in a note discussion:
<img src="https://user-images.githubusercontent.com/25306497/28995376-0d7a844e-79e8-11e7-8097-79be66e2e0a1.png" width="400px">

### Leave a note instead of answering a quest:
<img src="https://user-images.githubusercontent.com/25306497/28995377-122800d4-79e8-11e7-8850-9c898250aa20.png" width="400px">

P.S.: I'm probably not online in the next week, so you don't have to wonder why I'm not responding to your questions and ideas 😉 