### PR TITLE
handle 504 overpass error code like 429

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/OverpassMapDataDao.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/OverpassMapDataDao.java
@@ -61,7 +61,7 @@ public class OverpassMapDataDao
 		}
 		catch(OsmApiException e)
 		{
-			if(e.getErrorCode() == 429)
+			if(e.getErrorCode() == 429 || e.getErrorCode() == 504)
 				throw new OsmTooManyRequestsException(e.getErrorCode(), e.getErrorTitle(), e.getDescription());
 			else
 				throw e;


### PR DESCRIPTION
In my experience (see for example https://github.com/tilezen/vector-datasource/pull/1336) 504 error code also may happen, though it is quite rare and may be handled like 429.

Unfortunately this code is not tested as it is not possible to easily reproduce this situation.