### PR TITLE
avoid double use of cancel

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="upload_error">"Error while uploading answers"</string>
     <string name="cannot_find_bbox_or_reduce_tilt">"Can't scan here. Try to zoom in further or tilt the map less."</string>
     <string name="download_area_too_big">"Please zoom in further"</string>
-    <string name="confirmation_cancel_prev_download_title">"Cancel the current search and scan here instead?"</string>
+    <string name="confirmation_cancel_prev_download_title">"Stop the current search and scan here instead?"</string>
     <string name="notification_downloading">"Scanning for quests…"</string>
     <string name="now_downloading_toast">"Scanning for more quests…"</string>
     <string name="turn_on_location_request">"Location is off. Open Settings to turn it on now?"</string>


### PR DESCRIPTION
It attempts to make interface less confusing.

"Cancel the current search and scan here instead?" with buttons "OK" and "Cancel" is quite confusing.

previously: 'OK' button to confirm cancelling download, 'cancel' button to cancel cancelling
now: 'OK' button to confirm cancelling download, 'cancel' button to cancel stopping download