### PR TITLE
Fix noname restriction to only catch on value "yes"

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.java
@@ -50,7 +50,7 @@ public class AddPlaceName extends SimpleOverpassQuestType
 
 	@Override protected String getTagFilters()
 	{
-		return " nodes, ways, relations with !name and !noname and (" +
+		return " nodes, ways, relations with !name and noname != yes and (" +
 			   " shop and shop !~ no|vacant or" +
 			   " amenity ~ " + TextUtils.join("|",AMENITIES_WITH_NAMES) + " or" +
  			   " tourism ~ " + TextUtils.join("|",TOURISMS_WITH_NAMES) + " or" +


### PR DESCRIPTION
I think this also catches the case, when noname is not set, at least it is the same way [as you do here](https://github.com/westnordost/StreetComplete/blob/master/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.java#L38).