### PR TITLE
Add an extra application ID suffix for the debug version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
+        debug {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            applicationIdSuffix ".debug"
+        }
     }
 
     lintOptions {

--- a/app/src/debug/res/values-v17/strings.xml
+++ b/app/src/debug/res/values-v17/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- API 17 doesn't understand soft hyphens (and renders them as hyphens instead) -->
+    <string name="app_name" translatable="false">StreetComplete Dev</string>
+</resources>

--- a/app/src/debug/res/values-v18/strings.xml
+++ b/app/src/debug/res/values-v18/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- API 18 and up understand soft hyphens in that they at least don't render them when not necessary -->
+    <string name="app_name" translatable="false">Street­Complete Dev</string>
+</resources>

--- a/app/src/debug/res/values/untranslatableStrings.xml
+++ b/app/src/debug/res/values/untranslatableStrings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Street­Complete Dev</string>
+</resources>

--- a/app/src/debug/res/xml/preferences.xml
+++ b/app/src/debug/res/xml/preferences.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+                  xmlns:custom="http://schemas.android.com/apk/res/de.westnordost.streetcomplete.debug">
+
+    <PreferenceCategory
+        android:key="communication"
+        android:title="@string/pref_category_communication">
+
+        <ListPreference
+            android:key="autosync"
+            android:title="@string/pref_title_sync"
+            android:summary="%s"
+            android:defaultValue="ON"
+            android:entries="@array/pref_entries_autosync"
+            android:entryValues="@array/pref_entryvalues_autosync"
+            android:persistent="true"
+            />
+
+        <Preference
+            android:key="oauth"
+            android:title="@string/pref_title_authorization"
+            android:summary="@string/pref_title_not_authorized_summary"
+            android:persistent="true"
+            />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/pref_category_cache">
+
+        <de.westnordost.streetcomplete.settings.NumberPickerPreference
+            android:key="map.tilecache"
+            android:title="@string/pref_title_map_cache"
+            android:summary="@string/pref_tilecache_size_summary"
+            android:defaultValue="50"
+            android:persistent="true"
+            custom:minValue="1"
+            custom:maxValue="250"
+            android:dialogMessage="@string/pref_tilecache_size_message"
+            android:dialogLayout="@layout/numberpicker_preference"
+            android:positiveButtonText="@android:string/ok"
+            android:negativeButtonText="@android:string/cancel"
+            />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="display"
+        android:title="@string/pref_category_display">
+
+        <SwitchPreference
+            android:key="display.keepScreenOn"
+            android:title="@string/pref_title_keep_screen_on"
+            android:persistent="true"
+            />
+
+        <SwitchPreference
+            android:key="display.nonQuestionNotes"
+            android:title="@string/pref_title_show_notes_not_phrased_as_questions"
+            android:summaryOn="@string/pref_summaryOn_show_notes_not_phrased_as_questions"
+            android:summaryOff="@string/pref_summaryOff_show_notes_not_phrased_as_questions"
+            android:persistent="true"
+            />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>


### PR DESCRIPTION
This PR adds an application ID suffix for the debug version in the build.gradle file. It is then possible to have a stable version installed and besides also a version for debugging purposes.
The name of the application in the debug version is "StreetComplete Dev", so that you can distinguish between the two applications.
This PR fixes #591.
And this is how it looks like:
<img src="https://user-images.githubusercontent.com/25306497/31222076-1ff6af86-a9c6-11e7-873e-45fdf1f87339.png" width="300px"> <img src="https://user-images.githubusercontent.com/25306497/31222077-1ffa57f8-a9c6-11e7-9965-7e8585ba1065.png" width="300px">