### PR TITLE
Fix crash on startup due to directionMarker/directionMarkerSize race condition

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
@@ -151,9 +151,10 @@ public class MapFragment extends Fragment implements
 		locationMarker.setDrawable(dot);
 		locationMarker.setDrawOrder(3);
 
-		directionMarker = controller.addMarker();
 		BitmapDrawable directionImg = createBitmapDrawableFrom(R.drawable.location_direction);
 		directionMarkerSize = sizeInDp(directionImg);
+
+		directionMarker = controller.addMarker();
 		directionMarker.setDrawable(directionImg);
 		directionMarker.setDrawOrder(2);
 


### PR DESCRIPTION
I've been getting this error on startup of StreetComplete a few times:

```
Device: google bullhead, Android 8.0.0
Thread: Timer-0
App version: 2.1
Stack trace:
java.lang.NullPointerException: Attempt to get length of null array
at android.text.TextUtils.join(TextUtils.java:304)
at de.westnordost.streetcomplete.tangram.MapFragment.onRotationChanged(MapFragment.java:395)
at de.westnordost.streetcomplete.tangram.CompassComponent$CompassAnimator.run(CompassComponent.java:152)
at java.util.TimerThread.mainLoop(Timer.java:555)
at java.util.TimerThread.run(Timer.java:505)
```
It seems it is because `directionMarker` **is not null**, but `directionMarkerSize` **is null** in `onRotationChanged` in app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java.

Rearranging the initialisation in `initMarkers` so that `directionMarkerSize` is set before `directionMarker` is should solve the problem, even if `onRotationChanged` is called _during_ `initMarkers`, which does seem to happen for me, at least some of the time.

My instinct is telling me to set up all of the markers in local variables first, then assign them to the class so that they are either fully initialised or null when listeners fire, but I haven't gone that far here, just yet.

I've run this a few times, and it hasn't crashed yet, which it would do before semi-often. I'll run this over the next few days to be sure, though.