### PR TITLE
Enable non-digit characters on numeric keyboard for housenumbers

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumberForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumberForm.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.text.InputType;
+import android.text.method.DigitsKeyListener;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -85,6 +86,7 @@ public class AddHousenumberForm extends AbstractQuestFormAnswerFragment
 					} else
 					{
 						input.setInputType(InputType.TYPE_CLASS_NUMBER);
+						input.setKeyListener(DigitsKeyListener.getInstance("0123456789- /"));
 						toggleKeyboardButton.setText("abc");
 					}
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumberForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumberForm.java
@@ -86,7 +86,7 @@ public class AddHousenumberForm extends AbstractQuestFormAnswerFragment
 					} else
 					{
 						input.setInputType(InputType.TYPE_CLASS_NUMBER);
-						input.setKeyListener(DigitsKeyListener.getInstance("0123456789- /"));
+						input.setKeyListener(DigitsKeyListener.getInstance("0123456789.,- /"));
 						toggleKeyboardButton.setText("abc");
 					}
 

--- a/app/src/main/res/layout/quest_housenumber.xml
+++ b/app/src/main/res/layout/quest_housenumber.xml
@@ -21,7 +21,7 @@
         android:layout_gravity="center"
         android:text=""
         android:maxLines="1"
-        android:digits="0123456789- /"
+        android:digits="0123456789.,- /"
         />
 
     <Button

--- a/app/src/main/res/layout/quest_housenumber.xml
+++ b/app/src/main/res/layout/quest_housenumber.xml
@@ -21,6 +21,7 @@
         android:layout_gravity="center"
         android:text=""
         android:maxLines="1"
+        android:digits="0123456789- /"
         />
 
     <Button


### PR DESCRIPTION
When I try to add a street number like '4-6', even though the dash (`-`) is on the numeric keyboard, I can't add it without switching to the full keyboard.

This changes allows all the keys on my numeric keyboard to be used at any position in the 'number', as well as `/`. They keys allowed now are `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `.`, `,`, `-`, `/` and ` ` (space). If other numeric keyboards show other keys we may want to add them too.