### PR TITLE
upgrade gradle, migrate away from adroid-apt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
 
 def MAPZEN_API_KEY = hasProperty('mapzenApiKey') ? '"' + mapzenApiKey + '"' : "null";
 
@@ -8,7 +7,7 @@ android {
         release
     }
     compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    buildToolsVersion '26.0.2'
     testOptions {
         unitTests.returnDefaultValues = true
     }
@@ -73,8 +72,10 @@ dependencies {
     androidTestCompile "com.crittercism.dexmaker:dexmaker-mockito:1.4"
 
     // dependency injection
-    compile 'com.google.dagger:dagger:2.5'
-    apt 'com.google.dagger:dagger-compiler:2.5'
+    dependencies {
+        compile 'com.google.dagger:dagger:2.5'
+        annotationProcessor 'com.google.dagger:dagger-compiler:2.5'
+    }
 
     // Android stuff
     compile 'com.android.support:appcompat-v7:26.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 08 18:52:20 CET 2017
+#Sat Oct 28 19:20:45 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
migration done as recommended at https://bitbucket.org/hvisser/android-apt/wiki/Migration

fixes #667
makes possible to use Android Studio 3.0
removes deprecated plugin

If that is not desirable for some reason - it may be better to not upgrade to Android Studio 3.0

All 257 tests passed after this change.