### PR TITLE
Use local languages for names on the map

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -121,6 +122,8 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 	@Override protected void loadScene(String sceneFilePath)
 	{
 		List<SceneUpdate> sceneUpdates = spriteSheetCreator.get();
+		sceneUpdates.add(new SceneUpdate("global.ux_language", Locale.getDefault().getLanguage()));
+
 		controller.loadSceneFile(sceneFilePath, sceneUpdates);
 	}
 


### PR DESCRIPTION
This PR fixes #664. Every name on the map is now displayed is the users local language.
**Before:** (all names are in English)
<img src="https://user-images.githubusercontent.com/25306497/34469125-7a6a5ade-ef18-11e7-9521-2f63fd4d1760.png" width="300px">
**After:** (all names are in German)
<img src="https://user-images.githubusercontent.com/25306497/34469127-8002bcf2-ef18-11e7-91c8-e5d4392fb18f.png" width="300px">