### PR TITLE
protects agains crash if MAX_DISPLAYED_ITEMS is larger than number of items in list

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.java
@@ -96,7 +96,7 @@ public class AddSportForm extends ImageListQuestAnswerFragment
 			}
 		}
 		// only first 24 items (6 rows)
-		return sportsList.subList(0,MAX_DISPLAYED_ITEMS).toArray(new Item[MAX_DISPLAYED_ITEMS]);
+		return sportsList.subList(0,Math.min(sportsList.size(), MAX_DISPLAYED_ITEMS)).toArray(new Item[MAX_DISPLAYED_ITEMS]);
 	}
 
 	@Override protected void onClickOk()


### PR DESCRIPTION
it does not happen in unmodified StreetComplete but this change makes easier to avoid crashes if somebody modifies program

for example:

- somebody making quest starting from AddSport as base (just happened to me)
- significant increase of MAX_DISPLAYED_ITEMS (version for tablets?)