### PR TITLE
Adding a notification when upload to OSM is over

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
@@ -494,10 +494,10 @@ public class MainActivity extends AppCompatActivity implements
 
 		@AnyThread @Override public void onFinished()
 		{
-			Toast.makeText(
-					MainActivity.this,
-					"Finished uploading changes",
-					Toast.LENGTH_SHORT).show();
+			if (Prefs.Autosync.valueOf(prefs.getString(Prefs.AUTOSYNC,"ON")) == Prefs.Autosync.OFF)
+			{
+				Toast.makeText(MainActivity.this, "Finished uploading changes", Toast.LENGTH_SHORT).show();
+			}
 			runOnUiThread(() -> {
 				uploadedAnswersCounter.update();
 				unsyncedChangesCounter.update();

--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
@@ -496,7 +496,7 @@ public class MainActivity extends AppCompatActivity implements
 		{
 			if (Prefs.Autosync.valueOf(prefs.getString(Prefs.AUTOSYNC,"ON")) == Prefs.Autosync.OFF)
 			{
-				Toast.makeText(MainActivity.this, "Finished uploading changes", Toast.LENGTH_SHORT).show();
+				Toast.makeText(MainActivity.this, R.string.notify_end_upload_toast, Toast.LENGTH_SHORT).show();
 			}
 			runOnUiThread(() -> {
 				uploadedAnswersCounter.update();

--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
@@ -494,6 +494,10 @@ public class MainActivity extends AppCompatActivity implements
 
 		@AnyThread @Override public void onFinished()
 		{
+			Toast.makeText(
+					MainActivity.this,
+					"Finished uploading changes",
+					Toast.LENGTH_SHORT).show();
 			runOnUiThread(() -> {
 				uploadedAnswersCounter.update();
 				unsyncedChangesCounter.update();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,4 +456,5 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_generic_looks_like_this">Usually looks like this:</string>
     <string name="quest_surface_value_metal">Metal</string>
     <string name="quest_surface_generic_surface_confirmation">Are you sure that you can not determine the surface more specifically?</string>
+    <string name="notify_end_upload_toast">Finished uploading changes</string>
 </resources>


### PR DESCRIPTION
Very small usability improvement.

When autosync is OFF and the user hits the sync button with a big changeset after the end of a survey, it is not really clear when the upload is over or whether it actually happened, which can be a bit frustrating.

I have added a small toast to notify the user that the changes have been committed.