### PR TITLE
make order consistent

### DIFF
--- a/app/copyShopDescriptions.py
+++ b/app/copyShopDescriptions.py
@@ -25,7 +25,7 @@ def get_locale_from(dirname):
 		return components[1] + "-" + components[2][1:]
 	return None
 
-for dirname in os.listdir(source_dir):
+for dirname in sorted(os.listdir(source_dir)):
 	locale = get_locale_from(dirname)
 	if not locale:
 		continue

--- a/app/generateCountryMetadata.py
+++ b/app/generateCountryMetadata.py
@@ -11,7 +11,7 @@ if os.path.exists(targetDir):
 	shutil.rmtree(targetDir)
 os.makedirs(targetDir)
 
-for filename in os.listdir(sourceDir):
+for filename in sorted(os.listdir(sourceDir)):
 	print(filename)
 	if filename.endswith(".yml"):
 		basename = os.path.splitext(filename)[0]


### PR DESCRIPTION
os.listdir is allowed to return results in any order ( https://docs.python.org/3.5/library/os.html#os.listdir )
as it calls OS functions, on different OS order may be different
fixes #815