### PR TITLE
enable bikeway quest in additional countries

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.java
@@ -215,10 +215,10 @@ public class AddCycleway implements OsmElementQuestType
 			// all of Northern and Western Europe, most of Central Europe, some of Southern Europe
 			"NO","SE","FI","IS","DK",
 			"GB","IE","NL","BE","FR","LU",
-			"DE","PL","CZ","HU","AT","CH","LI",
-			"ES","IT",
+			"DE","PL","CZ","HU","AT","CH","LI","LT",
+			"ES","IT","SI","GR",
 			// East Asia
-			"JP","KR","TW",
+			"JP","KR","TW","SG",
 			// some of China (East Coast)
 			"CN-11","CN-12","CN-37","CN-32","CN-31",
 			"CN-33","CN-35","CN-44","CN-50",


### PR DESCRIPTION
SG - Singapore
LT - Lithuania
SI - Slovenia
GR - Greece

Done based on OSM data and checked whatever it seems to make sense

My OSM data check indicates that also some of following may qualify:

```
US-ME - Maine
US-MO - Missouri
US-KS - Kansas
US-OK - Oklahoma
US-AR - Arkansas
US-NE - Nebraska
US-IA - Iowa
US-KY - Kentucky
US-TN - Tennessee
US-MS - Mississippi
US-AL - Alabama
US-GA - Georgia
US-CO - Colorado
US-UT - Utah
US-NM - New Mexico
US-OH - Ohio
US-PA - Pennsylvania
US-DE - Delaware
US-MD - Maryland
US-ID - Idaho
US-NV - Nevada
US-HI - Hawaii
US-SC - South Carolina
US-VA - Virginia
US-NC - North Carolina
US-LA - Louisiana
CN-62 - Gansu
CN-41 - Henan
SK - Slovakia
AL - Albania
MK - Macedonia
BY - Belarus
BR - Brazil
RU - Russia
UA - Ukraine
EC - Ecuador
MX - Mexico
CO - Colombia
CL - Chile
BG - Bulgaria
BF - Burkina Faso
HR - Croatia
AR - Argentina
UY - Uruguay
PE - Peru
PT - Portugal
IN - India
ID - Indonesia
PH - Philippines
CA - Canada
IL - Israel
BA - Bosnia and Herzegovina
```