### PR TITLE
Tactile - country limitation

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.java
@@ -206,6 +206,8 @@ public class AddCycleway implements OsmElementQuestType
 	@Override public int getDefaultDisabledMessage() { return 0; }
 	@Override public Countries getEnabledForCountries()
 	{
+		// See overview here: https://ent8r.github.io/blacklistr/?java=bikeway/AddCycleway.java
+
 		// #749. sources:
 		// Google Street View (driving around in virtual car)
 		// https://en.wikivoyage.org/wiki/Cycling

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumber.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumber.java
@@ -156,6 +156,8 @@ public class AddHousenumber implements OsmElementQuestType
 
 	@Override public Countries getEnabledForCountries()
 	{
+		// See overview here: https://ent8r.github.io/blacklistr/?java=housenumber/AddHousenumber.java
+
 		return Countries.allExcept(new String[]{
 				"NL", // https://forum.openstreetmap.org/viewtopic.php?id=60356
 				"DK", // https://lists.openstreetmap.org/pipermail/talk-dk/2017-November/004898.html

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.java
@@ -55,5 +55,7 @@ public class AddTactilePavingBusStop extends SimpleOverpassQuestType
 				// generated from OSM data
 				"DE", "CH", "GB", "IE", "JP", "ES", "FR", "NL", "US-GA",
 			});
+		// See overview here: https://ent8r.github.io/blacklistr/?java=tactile_paving/AddTactilePavingBusStop.java
+		// #750
 	}
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import de.westnordost.streetcomplete.R;
+import de.westnordost.streetcomplete.data.osm.Countries;
 import de.westnordost.streetcomplete.data.osm.SimpleOverpassQuestType;
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder;
 import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao;
@@ -43,5 +44,16 @@ public class AddTactilePavingBusStop extends SimpleOverpassQuestType
 		boolean hasName = tags.containsKey("name");
 		if(hasName) return R.string.quest_tactilePaving_title_name_bus;
 		else        return R.string.quest_tactilePaving_title_bus;
+	}
+
+	@Override public Countries getEnabledForCountries()
+	{
+		return Countries.noneExcept(new String[]
+			{
+				// areas based on research
+				"CN-91", "SG", "AU", "NZ",
+				// generated from OSM data
+				"DE", "CH", "GB", "IE", "JP", "ES", "FR", "NL", "US-GA",
+			});
 	}
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingBusStop.java
@@ -48,14 +48,8 @@ public class AddTactilePavingBusStop extends SimpleOverpassQuestType
 
 	@Override public Countries getEnabledForCountries()
 	{
-		return Countries.noneExcept(new String[]
-			{
-				// areas based on research
-				"CN-91", "SG", "AU", "NZ",
-				// generated from OSM data
-				"DE", "CH", "GB", "IE", "JP", "ES", "FR", "NL", "US-GA",
-			});
 		// See overview here: https://ent8r.github.io/blacklistr/?java=tactile_paving/AddTactilePavingBusStop.java
 		// #750
+		return AddTactilePavingCrosswalk.ENBABLED_FOR_COUNTRIES;
 	}
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.java
@@ -44,17 +44,25 @@ public class AddTactilePavingCrosswalk extends SimpleOverpassQuestType
 		return R.string.quest_tactilePaving_title_crosswalk;
 	}
 
+	static final Countries ENBABLED_FOR_COUNTRIES = Countries.noneExcept(new String[]
+	{
+		// Europe
+		"NO","SE",
+		"GB","IE","NL","BE","FR","ES",
+		"DE","PL","CZ","SK","HU","AT","CH",
+		"LV","LT","EE","RU",
+		// America
+		"US","CA","AR",
+		// Asia
+		"CN-91","SG","KR","JP",
+		// Oceania
+		"AU","NZ",
+	});
+
     @Override public Countries getEnabledForCountries()
     {
-		return Countries.noneExcept(new String[]
-			{
-				// areas based on research
-				"CN-91", "SG", "AU", "NZ", "PL",
-				// generated from OSM data
-				"SK", "AT", "HU", "DE", "CZ", "BE", "SE", "GB", "IE",
-				"US", "AR", "ES", "CA", "FR", "NL", "RU",
-			});
 		// See overview here: https://ent8r.github.io/blacklistr/?java=tactile_paving/AddTactilePavingCrosswalk.java
 		// #750
+		return ENBABLED_FOR_COUNTRIES;
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.java
@@ -52,7 +52,7 @@ public class AddTactilePavingCrosswalk extends SimpleOverpassQuestType
 				"CN-91", "SG", "AU", "NZ", "PL",
 				// generated from OSM data
 				"SK", "AT", "HU", "DE", "CZ", "BE", "SE", "GB", "IE",
-				"US", "AR", "ES", "CA", "FR", "NL", "RU-MOW",
+				"US", "AR", "ES", "CA", "FR", "NL", "RU",
 			});
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.java
@@ -54,5 +54,7 @@ public class AddTactilePavingCrosswalk extends SimpleOverpassQuestType
 				"SK", "AT", "HU", "DE", "CZ", "BE", "SE", "GB", "IE",
 				"US", "AR", "ES", "CA", "FR", "NL", "RU",
 			});
+		// See overview here: https://ent8r.github.io/blacklistr/?java=tactile_paving/AddTactilePavingCrosswalk.java
+		// #750
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import de.westnordost.streetcomplete.R;
+import de.westnordost.streetcomplete.data.osm.Countries;
 import de.westnordost.streetcomplete.data.osm.SimpleOverpassQuestType;
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder;
 import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao;
@@ -42,4 +43,16 @@ public class AddTactilePavingCrosswalk extends SimpleOverpassQuestType
 	{
 		return R.string.quest_tactilePaving_title_crosswalk;
 	}
+
+    @Override public Countries getEnabledForCountries()
+    {
+		return Countries.noneExcept(new String[]
+			{
+				// areas based on research
+				"CN-91", "SG", "AU", "NZ", "PL",
+				// generated from OSM data
+				"SK", "AT", "HU", "DE", "CZ", "BE", "SE", "GB", "IE",
+				"US", "AR", "ES", "CA", "FR", "NL", "RU-MOW",
+			});
+    }
 }


### PR DESCRIPTION
PL is based on my general knowledge, Singapore, Honk Kong, New Zealand, Australia is based on reports in #750 

Reports for Poland, Australia (for both quests) and New Zealand, Singapore (for crosswalk quest) are confirmed by OSM data.


Other entries are based on sanitized OSM data.

Russia is tricky as AddTactilePavingCrosswalk should be displayed only for Moscow area (RU-MOW ISO code for area), but currently it is not technically possible in SC.

Tested in Honk Kong (downloads both quests) and in USA (downloads only crosswalk quest).

Parts generated from OSM data make sense, I expect that it may make sense to enable it also in additional countries, but based on feedback from #823 I went rather in direction of false negatives rather than false positives.

BTW, personally I would prefer enabling quests in all countries and disabling where excessive amount of =no answers appears as I consider collection of initial no answers as useful (it give info that in given region feature does not exists and allows to differentiate from cases where it exists and is not mapped).