### PR TITLE
is this feature still under construction?

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/meta/OsmTaggings.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/meta/OsmTaggings.java
@@ -7,4 +7,20 @@ public class OsmTaggings
 			"unpaved","compacted","gravel","fine_gravel","pebblestone","grass_paver",
 			"ground","earth","dirt","grass","sand","mud","ice","salt","snow","woodchips"
 	};
+
+	public static final String[] ALL_ROADS = {
+		"motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link",
+		"secondary", "secondary_link", "tertiary", "tertiary_link",
+		"unclassified", "residential", "living_street", "pedestrian",
+		"service", "track", "road",
+	};
+
+	// listed on https://wiki.openstreetmap.org/wiki/Key:access and used more than 5k times
+	public static final String[] POPULAR_ROAD_ACCESS_TAGS = {
+		"access", "foot", "vehicle", "bicycle", "carriage", "motor_vehicle", "motorcycle",
+		"mofa", "moped", "motorcar", "tourist_bus", "goods", "hgv", "agricultural", "snowmobile",
+		"psv", "hov", "emergency", "hazmat",
+	};
+
+	public static final String SURVEY_MARK_KEY = "check_date";
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/changes/StringMapChangesBuilder.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/changes/StringMapChangesBuilder.java
@@ -29,6 +29,15 @@ public class StringMapChangesBuilder
 		changes.put(key, new StringMapEntryDelete(key, valueBefore));
 	}
 
+	public void deleteIfPresent(@NonNull String key)
+	{
+		if(source.get(key) == null)
+		{
+			return;
+		}
+		delete(key);
+	}
+
 	public void add(@NonNull String key, @NonNull String value)
 	{
 		if(source.containsKey(key))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/DateHandler.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/DateHandler.java
@@ -1,0 +1,17 @@
+package de.westnordost.streetcomplete.quests;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+public class DateHandler {
+	public static String getOffsetDateString(int offsetInDays){
+		Calendar cal = Calendar.getInstance();
+		SimpleDateFormat basicISO8601 = new SimpleDateFormat("yyyy-MM-dd");
+		cal.add(Calendar.DAY_OF_MONTH, offsetInDays);
+		return basicISO8601.format(cal.getTime());
+	}
+
+	public static String getCurrentDateString() {
+		return getOffsetDateString(0);
+	}
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -18,7 +18,7 @@ import de.westnordost.streetcomplete.quests.bridge_structure.AddBridgeStructure;
 import de.westnordost.streetcomplete.quests.building_levels.AddBuildingLevels;
 import de.westnordost.streetcomplete.quests.bus_stop_shelter.AddBusStopShelter;
 import de.westnordost.streetcomplete.quests.car_wash_type.AddCarWashType;
-import de.westnordost.streetcomplete.quests.construction.MarkCompletedConstruction;
+import de.westnordost.streetcomplete.quests.construction.MarkCompletedHighwayConstruction;
 import de.westnordost.streetcomplete.quests.crossing_type.AddCrossingType;
 import de.westnordost.streetcomplete.quests.diet_type.AddVegan;
 import de.westnordost.streetcomplete.quests.diet_type.AddVegetarian;
@@ -65,7 +65,7 @@ public class QuestModule
 				// ↓ 2. important data that is used by many data consumers
 				new AddRoadName(o, roadNameSuggestionsDao, putRoadNameSuggestionsHandler),
 				new AddHousenumber(o),
-				new MarkCompletedConstruction(o),
+				new MarkCompletedHighwayConstruction(o),
 				// new AddPlaceName(o), doesn't make sense as long as the app cannot tell the generic name of elements
 
 				// ↓ 3. useful data that is used by some data consumers

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -18,6 +18,7 @@ import de.westnordost.streetcomplete.quests.bridge_structure.AddBridgeStructure;
 import de.westnordost.streetcomplete.quests.building_levels.AddBuildingLevels;
 import de.westnordost.streetcomplete.quests.bus_stop_shelter.AddBusStopShelter;
 import de.westnordost.streetcomplete.quests.car_wash_type.AddCarWashType;
+import de.westnordost.streetcomplete.quests.construction.MarkCompletedConstruction;
 import de.westnordost.streetcomplete.quests.crossing_type.AddCrossingType;
 import de.westnordost.streetcomplete.quests.diet_type.AddVegan;
 import de.westnordost.streetcomplete.quests.diet_type.AddVegetarian;
@@ -61,10 +62,10 @@ public class QuestModule
 		QuestType[] questTypesOrderedByImportance = {
 				// ↓ 1. notes
 				osmNoteQuestType,
-
 				// ↓ 2. important data that is used by many data consumers
 				new AddRoadName(o, roadNameSuggestionsDao, putRoadNameSuggestionsHandler),
 				new AddHousenumber(o),
+				new MarkCompletedConstruction(o),
 				// new AddPlaceName(o), doesn't make sense as long as the app cannot tell the generic name of elements
 
 				// ↓ 3. useful data that is used by some data consumers

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -62,6 +62,7 @@ public class QuestModule
 		QuestType[] questTypesOrderedByImportance = {
 				// ↓ 1. notes
 				osmNoteQuestType,
+
 				// ↓ 2. important data that is used by many data consumers
 				new AddRoadName(o, roadNameSuggestionsDao, putRoadNameSuggestionsHandler),
 				new AddHousenumber(o),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstruction.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstruction.java
@@ -1,0 +1,174 @@
+package de.westnordost.streetcomplete.quests.construction;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import de.westnordost.osmapi.map.data.BoundingBox;
+import de.westnordost.osmapi.map.data.Element;
+import de.westnordost.streetcomplete.R;
+import de.westnordost.streetcomplete.data.meta.OsmTaggings;
+import de.westnordost.streetcomplete.data.osm.Countries;
+import de.westnordost.streetcomplete.data.osm.OsmElementQuestType;
+import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder;
+import de.westnordost.streetcomplete.data.osm.download.MapDataWithGeometryHandler;
+import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao;
+import de.westnordost.streetcomplete.data.osm.tql.OverpassQLUtil;
+import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment;
+import de.westnordost.streetcomplete.quests.DateHandler;
+import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment;
+
+public class MarkCompletedConstruction  implements OsmElementQuestType
+{
+	private final OverpassMapDataDao overpassServer;
+
+	@Inject
+	public MarkCompletedConstruction(OverpassMapDataDao overpassServer)
+	{
+		this.overpassServer = overpassServer;
+	}
+
+	@Nullable
+	@Override public Boolean isApplicableTo(Element element)
+	{
+		/* Whether this element applies to this quest cannot be determined by looking at that
+		   element alone (see download()), an Overpass query would need to be made to find this out.
+		   This is too heavy-weight for this method so it always returns false. */
+
+		/* The implications of this are that this quest will never be created directly
+		   as consequence of solving another quest and also after reverting an input,
+		   the quest will not immediately pop up again. Instead, they are downloaded well after an
+		   element became fit for this quest. */
+		return null;
+	}
+
+	@Override public boolean download(BoundingBox bbox, MapDataWithGeometryHandler handler)
+	{
+		return overpassServer.getAndHandleQuota(getOverpassQuery(bbox), handler);
+	}
+
+	/** @return overpass query string to get streets marked as under construction but excluding ones
+	 * - with invalid construction tag
+	 * - with tagged opening date that is in future
+	 * - recently edited (includes adding/updating check_date tags)
+	 * - with fixme (as in some situations this quest may add fixme note as an edit)
+	 * . */
+	private static String getOverpassQuery(BoundingBox bbox)
+	{
+		String currentDate = DateHandler.getCurrentDateString() + "T00:00:00Z";
+		String twoWeeksAgo = DateHandler.getOffsetDateString(-14) + "T00:00:00Z";
+
+		ArrayList<String> acceptedConstructionValues = new ArrayList<String>(Arrays.asList(OsmTaggings.ALL_ROADS));
+		acceptedConstructionValues.add("cycleway");
+		acceptedConstructionValues.add("footway");
+		acceptedConstructionValues.add("path");
+
+		String query = OverpassQLUtil.getOverpassBBox(bbox) +
+			"way[highway=construction] -> .all_roads_under_construction;" +
+			"(" +
+			"way[construction]" +
+				"[construction !~ \"^("+ TextUtils.join("|", acceptedConstructionValues)+")$\"]" +
+			") -> .invalid_construction_type;" +
+			"(" +
+			"way[highway=construction][opening_date](" +
+			"  if:is_date(t['opening_date']) && date(t['opening_date'])>date('" + currentDate + "'));" +
+			") -> .known_opening_date_in_future;" +
+			"(" +
+			"  way[highway=construction](newer:'" + twoWeeksAgo + "');" +
+			") -> .recently_edited;" +
+			"(" +
+			"  way[highway=construction][fixme];" +
+			") -> .with_fixme;" +
+			"(" +
+			"(((" +
+			"	.all_roads_under_construction" +
+			"	- .known_opening_date_in_future)" +
+			"	- .recently_edited)" +
+			"	- .with_fixme)" +
+			"	- .invalid_construction_type;" +
+			");" +
+			"out meta geom;";
+		Log.e("tag", query);
+		return query;
+	}
+
+	public AbstractQuestAnswerFragment createForm()
+	{
+		return new YesNoQuestAnswerFragment();
+	}
+
+	public void applyAnswerTo(Bundle answer, StringMapChangesBuilder changes)
+	{
+		if(answer.getBoolean(YesNoQuestAnswerFragment.ANSWER)) {
+			if(isAnyAccessTagPresent(changes)){
+				// there are some access tag present that are likely to be temporary
+				// and valid only during construction - marking construction as finished
+				// would likely cause nonobvious tagging mistake
+				changes.add("fixme", "construction is completed but there are access tags that may be true only during construction period");
+				return;
+			}
+			String constructionValue = changes.getPreviousValue("construction");
+			if(constructionValue == null) {
+				constructionValue = "road";
+			}
+			changes.deleteIfPresent("construction");
+			changes.deleteIfPresent("source:construction");
+			changes.modify("highway", constructionValue);
+			changes.deleteIfPresent("opening_date");
+			changes.deleteIfPresent("source:opening_date");
+			changes.deleteIfPresent(OsmTaggings.SURVEY_MARK_KEY);
+		} else {
+			changes.addOrModify(OsmTaggings.SURVEY_MARK_KEY, DateHandler.getCurrentDateString());
+		}
+	}
+
+	private boolean isAnyAccessTagPresent(StringMapChangesBuilder changes){
+		for(String accessTag : OsmTaggings.POPULAR_ROAD_ACCESS_TAGS){
+			if(changes.getPreviousValue(accessTag) != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override public String getCommitMessage() { return "Add whether construction is now completed"; }
+
+	@Override public int getIcon() { return R.drawable.ic_quest_ferry; } //TODO, use a better icon
+
+	@Override
+	public int getTitle() {
+		return R.string.quest_construction_road_title;
+	}
+
+	@Override public int getTitle(@NonNull Map<String, String> tags) {
+		if (Arrays.asList(OsmTaggings.ALL_ROADS).contains(tags.get("construction"))){
+			return R.string.quest_construction_road_title;
+		} else if (tags.get("construction") == "cycleway") {
+			return R.string.quest_construction_cycleway_title;
+		} else if (tags.get("construction") == "footway") {
+			return R.string.quest_construction_footway_title;
+		}
+		return R.string.quest_construction_generic_title;
+	}
+
+	@NonNull
+	@Override
+	public Countries getEnabledForCountries() {
+		return Countries.ALL;
+	}
+
+	@Override
+	public int getDefaultDisabledMessage() {
+		return 0;
+	}
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstruction.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedConstruction.java
@@ -110,6 +110,8 @@ public class MarkCompletedConstruction  implements OsmElementQuestType
 	public void applyAnswerTo(Bundle answer, StringMapChangesBuilder changes)
 	{
 		if(answer.getBoolean(YesNoQuestAnswerFragment.ANSWER)) {
+			changes.addOrModify(OsmTaggings.SURVEY_MARK_KEY, DateHandler.getCurrentDateString());
+		} else {
 			if(isAnyAccessTagPresent(changes)){
 				// there are some access tag present that are likely to be temporary
 				// and valid only during construction - marking construction as finished
@@ -127,8 +129,6 @@ public class MarkCompletedConstruction  implements OsmElementQuestType
 			changes.deleteIfPresent("opening_date");
 			changes.deleteIfPresent("source:opening_date");
 			changes.deleteIfPresent(OsmTaggings.SURVEY_MARK_KEY);
-		} else {
-			changes.addOrModify(OsmTaggings.SURVEY_MARK_KEY, DateHandler.getCurrentDateString());
 		}
 	}
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.java
@@ -68,30 +68,26 @@ public class MarkCompletedHighwayConstruction implements OsmElementQuestType
 		String currentDate = DateHandler.getCurrentDateString() + "T00:00:00Z";
 		String twoWeeksAgo = DateHandler.getOffsetDateString(-14) + "T00:00:00Z";
 
-		ArrayList<String> acceptedConstructionValues = new ArrayList<String>(Arrays.asList(OsmTaggings.ALL_ROADS));
-		acceptedConstructionValues.add("cycleway");
-		acceptedConstructionValues.add("footway");
-		acceptedConstructionValues.add("path");
 
 		String query = OverpassQLUtil.getOverpassBBox(bbox) +
-			"way[highway=construction] -> .all_roads_under_construction;" +
+			"way[" + mainKeyName() + "=construction] -> .all_ways_under_construction;" +
 			"(" +
 			"way[construction]" +
-				"[construction !~ \"^("+ TextUtils.join("|", acceptedConstructionValues)+")$\"]" +
+				"[construction !~ \"^("+ TextUtils.join("|", validConstructionValues())+")$\"]" +
 			") -> .invalid_construction_type;" +
 			"(" +
-			"way[highway=construction][opening_date](" +
+			"way[" + mainKeyName() + "=construction][opening_date](" +
 			"  if:is_date(t['opening_date']) && date(t['opening_date'])>date('" + currentDate + "'));" +
 			") -> .known_opening_date_in_future;" +
 			"(" +
-			"  way[highway=construction](newer:'" + twoWeeksAgo + "');" +
+			"  way[" + mainKeyName() + "=construction](newer:'" + twoWeeksAgo + "');" +
 			") -> .recently_edited;" +
 			"(" +
-			"  way[highway=construction][fixme];" +
+			"  way[" + mainKeyName() + "=construction][fixme];" +
 			") -> .with_fixme;" +
 			"(" +
 			"(((" +
-			"	.all_roads_under_construction" +
+			"	.all_ways_under_construction" +
 			"	- .known_opening_date_in_future)" +
 			"	- .recently_edited)" +
 			"	- .with_fixme)" +
@@ -100,6 +96,18 @@ public class MarkCompletedHighwayConstruction implements OsmElementQuestType
 			"out meta geom;";
 		Log.e("tag", query);
 		return query;
+	}
+
+	private static ArrayList<String> validConstructionValues(){
+		ArrayList<String> validConstructionValues = new ArrayList<String>(Arrays.asList(OsmTaggings.ALL_ROADS));
+		validConstructionValues.add("cycleway");
+		validConstructionValues.add("footway");
+		validConstructionValues.add("path");
+		return validConstructionValues;
+	}
+
+	private static String mainKeyName() {
+		return "highway";
 	}
 
 	public AbstractQuestAnswerFragment createForm()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/construction/MarkCompletedHighwayConstruction.java
@@ -28,12 +28,12 @@ import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment;
 import de.westnordost.streetcomplete.quests.DateHandler;
 import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment;
 
-public class MarkCompletedConstruction  implements OsmElementQuestType
+public class MarkCompletedHighwayConstruction implements OsmElementQuestType
 {
 	private final OverpassMapDataDao overpassServer;
 
 	@Inject
-	public MarkCompletedConstruction(OverpassMapDataDao overpassServer)
+	public MarkCompletedHighwayConstruction(OverpassMapDataDao overpassServer)
 	{
 		this.overpassServer = overpassServer;
 	}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -488,4 +488,8 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_parking_access_private">It is private</string>
     <string name="quest_parking_access_yes">It is public (with or without fee)</string>
     <string name="quest_parking_access_customers">It is only for customers</string>
+    <string name="quest_construction_road_title">Is construction of this road completed?</string>
+    <string name="quest_construction_cycleway_title">Is construction of this cycleway completed?</string>
+    <string name="quest_construction_footway_title">Is construction of this footway completed?</string>
+    <string name="quest_construction_generic_title">Is construction of this way completed?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -488,8 +488,8 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_parking_access_private">It is private</string>
     <string name="quest_parking_access_yes">It is public (with or without fee)</string>
     <string name="quest_parking_access_customers">It is only for customers</string>
-    <string name="quest_construction_road_title">Is construction of this road completed?</string>
-    <string name="quest_construction_cycleway_title">Is construction of this cycleway completed?</string>
-    <string name="quest_construction_footway_title">Is construction of this footway completed?</string>
-    <string name="quest_construction_generic_title">Is construction of this way completed?</string>
+    <string name="quest_construction_road_title">Is this road still under construction?</string>
+    <string name="quest_construction_cycleway_title">Is this cycleway still under construction?</string>
+    <string name="quest_construction_footway_title">Is this footway still under construction?</string>
+    <string name="quest_construction_generic_title">Is this way still under construction?</string>
 </resources>


### PR DESCRIPTION
I am opening this PR mostly because I am looking for code/feature review.

Before further work I  want to verify that quest for handling of railway=construction and building=construction like highway=construction is wanted.

I planned to support handling railway=construction and highway=construction by using abstract class with all functions, with MarkCompletedHighwayConstruction overriding validConstructionValues, mainKeyName, StringMapChangesBuilder, getCommitMessage, getTitle (mostly to avoid duplicating query logic in getOverpassQuery) but it failed due to Java blocking overriding of static methods and forbidding abstract static methods.

I am now planning to put getOverpassQuery logic into a separate static class.