### PR TITLE
Differenciate between roads and pedestrian streets

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.java
@@ -165,8 +165,7 @@ public class AddRoadName implements OsmElementQuestType
 	@Override public int getIcon() { return R.drawable.ic_quest_street_name; }
 	@Override public int getTitle() { return R.string.quest_streetName_title; }
 	@Override public int getTitle(@NonNull Map<String,String> tags) {
-		if (tags.containsKey("area") && tags.get("area").equals("yes")) return R.string.quest_streetName_square_title;
-		else if (tags.get("highway").equals("pedestrian")) return R.string.quest_streetName_pedestrian_title;
+		if (tags.get("highway").equals("pedestrian")) return R.string.quest_streetName_pedestrian_title;
 		else return R.string.quest_streetName_title;
 	}
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.java
@@ -165,7 +165,8 @@ public class AddRoadName implements OsmElementQuestType
 	@Override public int getIcon() { return R.drawable.ic_quest_street_name; }
 	@Override public int getTitle() { return R.string.quest_streetName_title; }
 	@Override public int getTitle(@NonNull Map<String,String> tags) {
-		if (tags.get("highway").equals("pedestrian")) return R.string.quest_streetName_pedestrian_title;
+		if (tags.containsKey("area") && tags.get("area").equals("yes")) return R.string.quest_streetName_square_title;
+		else if (tags.get("highway").equals("pedestrian")) return R.string.quest_streetName_pedestrian_title;
 		else return R.string.quest_streetName_title;
 	}
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_name/AddRoadName.java
@@ -164,7 +164,10 @@ public class AddRoadName implements OsmElementQuestType
 	@Override public String getCommitMessage() { return "Determine road names and types"; }
 	@Override public int getIcon() { return R.drawable.ic_quest_street_name; }
 	@Override public int getTitle() { return R.string.quest_streetName_title; }
-	@Override public int getTitle(@NonNull Map<String,String> tags) { return getTitle(); }
+	@Override public int getTitle(@NonNull Map<String,String> tags) {
+		if (tags.get("highway").equals("pedestrian")) return R.string.quest_streetName_pedestrian_title;
+		else return R.string.quest_streetName_title;
+	}
 
 	@Override public int getDefaultDisabledMessage() { return 0; }
 	@NonNull @Override public Countries getEnabledForCountries() { return Countries.ALL; }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/road_surface/AddRoadSurface.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/road_surface/AddRoadSurface.java
@@ -49,7 +49,16 @@ public class AddRoadSurface extends SimpleOverpassQuestType
 	@Override public int getTitle(@NonNull Map<String, String> tags)
 	{
 		boolean hasName = tags.containsKey("name");
-		if(hasName) return R.string.quest_streetSurface_name_title;
-		else        return R.string.quest_streetSurface_title;
+		boolean isSquare = tags.containsKey("area") && tags.get("area").equals("yes");
+		if(hasName)
+		{
+			if(isSquare) return R.string.quest_streetSurface_square_name_title;
+			else return R.string.quest_streetSurface_name_title;
+		}
+		else
+		{
+			if(isSquare) return R.string.quest_streetSurface_square_title;
+			else return R.string.quest_streetSurface_title;
+		}
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -489,4 +489,5 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_parking_access_yes">It is public (with or without fee)</string>
     <string name="quest_parking_access_customers">It is only for customers</string>
     <string name="quest_streetName_pedestrian_title">What is the name of this pedestrian street?</string>
+    <string name="quest_streetName_square_title">What is the name of this square?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -488,4 +488,5 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_parking_access_private">It is private</string>
     <string name="quest_parking_access_yes">It is public (with or without fee)</string>
     <string name="quest_parking_access_customers">It is only for customers</string>
+    <string name="quest_streetName_pedestrian_title">What is the name of this pedestrian street?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -489,5 +489,6 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_parking_access_yes">It is public (with or without fee)</string>
     <string name="quest_parking_access_customers">It is only for customers</string>
     <string name="quest_streetName_pedestrian_title">What is the name of this pedestrian street?</string>
-    <string name="quest_streetName_square_title">What is the name of this square?</string>
+    <string name="quest_streetSurface_square_title">"What surface does this square have?"</string>
+    <string name="quest_streetSurface_square_name_title">"What surface does the square \"%s\" have here?"</string>
 </resources>


### PR DESCRIPTION
While reviewing StreetComplete-related notes I saw many people irritated by the fact that StreetComplete can't differenciate between roads for cars and pedestrian streets.
This PR fixes this issue.

**Some examples are:**
https://www.openstreetmap.org/note/1296735
https://www.openstreetmap.org/note/1179245
https://www.openstreetmap.org/note/1174269
https://www.openstreetmap.org/note/1174268
https://www.openstreetmap.org/note/1174267
https://www.openstreetmap.org/note/1123039
https://www.openstreetmap.org/note/1290931
https://www.openstreetmap.org/note/1289562