### PR TITLE
Exclude private elements from bike parking capacity quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.java
@@ -22,7 +22,7 @@ public class AddBikeParkingCapacity extends SimpleOverpassQuestType
 
 	@Override protected String getTagFilters()
 	{
-		return "nodes, ways with amenity=bicycle_parking and !capacity";
+		return "nodes, ways with amenity=bicycle_parking and !capacity and (access !~ private|no)";
 	}
 
 	public AbstractQuestAnswerFragment createForm()


### PR DESCRIPTION
The quest for covered bike parkings does already exclude private elements: https://github.com/westnordost/StreetComplete/blob/00ede6b6ec3763fab38d4ab5c457ecf13ec950a2/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.java#L23
and I also encountered some notes for this quest saying that the object is unaccessible even if the bike parking was already tagged with `access=private`...