### PR TITLE
Opening Hours: Expect Swedish opening hours to differ on Saturdays

### DIFF
--- a/app/src/main/assets/country_metadata/SE.yml
+++ b/app/src/main/assets/country_metadata/SE.yml
@@ -6,3 +6,4 @@ isSlowZoneKnown: true
 officialLanguages: [sv]
 orchardProduces: [blueberry, strawberry, apple, cherry, raspberry, pear, plum, tomatoe]
 popularSports: [soccer, tennis, basketball, golf, boules, equestrian, ice_hockey]
+regularShoppingDays: 5

--- a/res/country_metadata/regularShoppingDays.yml
+++ b/res/country_metadata/regularShoppingDays.yml
@@ -4,3 +4,4 @@ default: 6
 AT: 5
 DE: 5
 PL: 5
+SE: 5


### PR DESCRIPTION
While a lot of shops in a big city in Sweden are open all days of
the week, Monday to Friday tend to have the same opening hours,
but shorter opening hours on Saturdays and Sundays.
This means that when setting the opening hours in StreetComplete,
you always have to uncheck Saturday first.

This commit fixes it to be Monday-Friday by default.