### PR TITLE
stop holding key names in variable names

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
+import java.util.Hashtable;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -19,44 +20,47 @@ public class AddPlaceName extends SimpleOverpassQuestType
 
 	// not all amenities have names. Rather have an inclusive list here than an exclusive one. This
 	// list goes down to a few hundred (documented) elements in taginfo (Mar 2017)
-	private static final String[] AMENITIES_WITH_NAMES = {
-			"restaurant","cafe","ice_cream","fast_food","bar","pub","biergarten","food_court","nightclub",		// eat & drink
-			"cinema","theatre","planetarium","arts_centre","studio",											// culture
-			"events_venue","conference_centre","exhibition_centre","music_venue",								// events
-			"townhall","prison","courthouse","embassy","police","fire_station","ranger_station",				// civic
-			"bank","atm","bureau_de_change","money_transfer", "post_office","library","marketplace",			// commercial
-			"community_centre","social_facility","nursing_home","childcare","retirement_home","social_centre",	// social
-			"car_wash","car_rental","boat_rental","fuel",														// car stuff
-			"dentist","doctors","clinic","pharmacy","hospital",													// health care
-			"place_of_worship","monastery",																		// religious
-			"kindergarten","school","college","university","research_institute",								// education
-			"driving_school","dive_centre","language_school","music_school",									// learning
-			"casino","brothel","gambling","love_hotel","stripclub",												// bad stuff
-			"animal_boarding","animal_shelter","animal_breeding","veterinary",									// animals
-	};
 
-	private static final String[] TOURISMS_WITH_NAMES = {
-			"attraction","zoo","aquarium","theme_park","gallery","museum",											// attractions
-			"hotel","guest_house","motel","hostel","alpine_hut","apartment","resort","camp_site", "caravan_site",	// accomodations
+	private static final Hashtable<String, String[]> OBJECTS_WITH_NAMES = new Hashtable<String,String[]>() {{
+		put("amenity", new String[]{
+			"restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub",        // eat & drink
+			"cinema", "theatre", "planetarium", "arts_centre", "studio",                                            // culture
+			"events_venue", "conference_centre", "exhibition_centre", "music_venue",                                // events
+			"townhall", "prison", "courthouse", "embassy", "police", "fire_station", "ranger_station",                // civic
+			"bank", "atm", "bureau_de_change", "money_transfer", "post_office", "library", "marketplace",            // commercial
+			"community_centre", "social_facility", "nursing_home", "childcare", "retirement_home", "social_centre",    // social
+			"car_wash", "car_rental", "boat_rental", "fuel",                                                        // car stuff
+			"dentist", "doctors", "clinic", "pharmacy", "hospital",                                                    // health care
+			"place_of_worship", "monastery",                                                                        // religious
+			"kindergarten", "school", "college", "university", "research_institute",                                // education
+			"driving_school", "dive_centre", "language_school", "music_school",                                    // learning
+			"casino", "brothel", "gambling", "love_hotel", "stripclub",                                                // bad stuff
+			"animal_boarding", "animal_shelter", "animal_breeding", "veterinary",                                    // animals
+		});
+		put("tourism", new String[]{
+			"attraction", "zoo", "aquarium", "theme_park", "gallery", "museum",                                            // attractions
+			"hotel", "guest_house", "motel", "hostel", "alpine_hut", "apartment", "resort", "camp_site", "caravan_site",    // accomodations
 			// and tourism=info, see below
-	};
-
-	private static final String[] LEISURES_WITH_NAMES = {
+		});
+		put("leisure", new String[]{
 			"park","nature_reserve", "sports_centre","fitness_centre","dance","golf_course",
 			"water_park","miniature_golf", "stadium","marina","bowling_alley", "amusement_arcade",
 			"adult_gaming_centre", "tanning_salon","horse_riding"
-	};
+		});
+	}};
 
 	@Inject public AddPlaceName(OverpassMapDataDao overpassServer) { super(overpassServer); }
 
 	@Override protected String getTagFilters()
 	{
-		return " nodes, ways, relations with !name and noname != yes and (" +
-			   " shop and shop !~ no|vacant or" +
-			   " amenity ~ " + TextUtils.join("|",AMENITIES_WITH_NAMES) + " or" +
- 			   " tourism ~ " + TextUtils.join("|",TOURISMS_WITH_NAMES) + " or" +
-			   " tourism = information and information = office or" +
-			   " leisure ~ " + TextUtils.join("|",LEISURES_WITH_NAMES) + " )";
+		String query = " nodes, ways, relations with !name and noname != yes and (" +
+			   " shop and shop !~ no|vacant" +
+			   " or tourism = information and information = office";
+		for(String key: OBJECTS_WITH_NAMES.keySet()){
+			query += " or (" +key + "~ " + TextUtils.join("|",OBJECTS_WITH_NAMES.get(key)) + " )";
+		}
+		query += ")";
+		return query;
 	}
 
 	@Override public AbstractQuestAnswerFragment createForm()


### PR DESCRIPTION
this change is supposed to make adding new keys to this quest easier (so now adding say waterway=waterfall requires change in one place rather than two).

This change is tested (I [enabled](https://github.com/matkoniecz/Zazolc/commit/faf5d9cf135226f89d01a105d7388000a395ef06) this quest in my fork).