### PR TITLE
report text of malformed querries in Logcat

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/OverpassMapDataDao.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/OverpassMapDataDao.java
@@ -61,10 +61,14 @@ public class OverpassMapDataDao
 		}
 		catch(OsmApiException e)
 		{
-			if(e.getErrorCode() == 429)
+			if(e.getErrorCode() == 429) {
 				throw new OsmTooManyRequestsException(e.getErrorCode(), e.getErrorTitle(), e.getDescription());
-			else
+			} else if(e.getErrorCode() == 400) {
+				Log.e(TAG, "malformed query, caused Overpass to return error code 400: " + query);
 				throw e;
+			} else {
+				throw e;
+			}
 		}
 	}
 


### PR DESCRIPTION
removes need to create temporary debugging statements during development
currently with code causing 400 errors one must create temporary debug entry outputting failing query, now this will be done automatically

part of fixing https://github.com/westnordost/StreetComplete/commit/24ac2561e7a450fe5d073c890311fa57aec6bf5c that is part of fixing #920 that is part of fixing #685 :)