### PR TITLE
in tests of Housenumber query use OSM data as it was at specified time

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/quests/add_housenumber/AddHousenumberIntegrationTest.java
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/quests/add_housenumber/AddHousenumberIntegrationTest.java
@@ -11,99 +11,96 @@ import de.westnordost.streetcomplete.quests.housenumber.AddHousenumber;
 
 public class AddHousenumberIntegrationTest extends TestCase
 {
-	private AddHousenumber quest;
 
-	// these tests are dependent on actual data on OSM, which may change of course... so then the
-	// tests need to be adapted... :-/
-
-	@Override public void setUp() throws Exception
+	public void test_unspecified_building_type_is_excluded()
 	{
-		super.setUp();
-		OverpassMapDataDao o = OsmModule.overpassMapDataDao(OsmModule::overpassMapDataParser);
-		quest = new AddHousenumber(o);
+		//test is using https://www.openstreetmap.org/way/139545168/history, version 3
+		verifyYieldsNoQuest(new BoundingBox(50.06655, 19.93690, 50.06681, 19.93740), "2014-03-01");
 	}
 
 	public void test_underground_building_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(52.5149999, 13.417933, 52.516198, 13.4183836));
+		verifyYieldsNoQuest(new BoundingBox(52.5149999, 13.417933, 52.516198, 13.4183836), "2018-03-01");
 	}
 
 	public void test_building_type_that_likely_has_no_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5312195, 9.9804139, 53.531559, 9.9808994));
+		verifyYieldsNoQuest(new BoundingBox(53.5312195, 9.9804139, 53.531559, 9.9808994), "2018-03-01");
 	}
 
 	/* --------------------------------- buildings with address --------------------------------- */
 
 	public void test_building_with_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(52.3812058, 13.0742659, 52.3815491, 13.0748789));
+		verifyYieldsNoQuest(new BoundingBox(52.3812058, 13.0742659, 52.3815491, 13.0748789), "2018-03-01");
 	}
 
 	public void test_relation_building_with_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5465806, 9.934811, 53.5473838, 9.9359912));
+		verifyYieldsNoQuest(new BoundingBox(53.5465806, 9.934811, 53.5473838, 9.9359912), "2018-03-01");
 	}
 
 	/* --------------------------- buildings with address node inside --------------------------- */
 
 	public void test_building_with_address_inside_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(59.9152277, 10.7040524, 59.9155073, 10.7045299));
+		verifyYieldsNoQuest(new BoundingBox(59.9152277, 10.7040524, 59.9155073, 10.7045299), "2018-03-01");
 	}
 
 	public void test_building_with_address_inside_but_outside_boundingBox_is_excluded_nevertheless()
 	{
-		verifyYieldsNoQuest(new BoundingBox(59.9154105, 10.7041866, 59.9154966, 10.7045299));
+		verifyYieldsNoQuest(new BoundingBox(59.9154105, 10.7041866, 59.9154966, 10.7045299), "2018-03-01");
 	}
 
 
 	public void test_relation_building_with_address_inside_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(59.9125977,10.7393879,59.9133372,10.740847));
+		verifyYieldsNoQuest(new BoundingBox(59.9125977,10.7393879,59.9133372,10.740847), "2018-03-01");
 	}
 
 	public void test_relation_building_with_address_inside_but_outside_boundingBox_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(59.9125506,10.7404044,59.9126326,10.7405975));
+		verifyYieldsNoQuest(new BoundingBox(59.9125506,10.7404044,59.9126326,10.7405975), "2018-03-01");
 	}
 
 	/* ------------------------- buildings with address node on outline ------------------------- */
 
 	public void test_building_with_address_on_outline_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(52.380765, 13.0748677, 52.3809697, 13.075211));
+		verifyYieldsNoQuest(new BoundingBox(52.380765, 13.0748677, 52.3809697, 13.075211), "2018-03-01");
 	}
 
 	public void test_building_with_address_on_outline_but_outside_boundingBox_is_excluded_nevertheless()
 	{
-		verifyYieldsNoQuest(new BoundingBox(52.3807601, 13.0748811, 52.3808796, 13.0752191));
+		verifyYieldsNoQuest(new BoundingBox(52.3807601, 13.0748811, 52.3808796, 13.0752191), "2018-03-01");
 	}
 
 	public void test_relation_building_with_address_on_outline_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5546534, 9.9783272, 53.5550996, 9.9797165));
+		verifyYieldsNoQuest(new BoundingBox(53.5546534, 9.9783272, 53.5550996, 9.9797165), "2018-03-01");
 	}
 
 	public void test_relation_building_with_address_on_outline_but_outside_boundingBox_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5546869,9.9788234,53.5549896,9.9790755));
+		verifyYieldsNoQuest(new BoundingBox(53.5546869,9.9788234,53.5549896,9.9790755), "2018-03-01");
 	}
 
 	/* --------------------------- buildings within area with address --------------------------- */
 
 	public void test_building_within_area_with_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5738493, 9.9408299, 53.5741742, 9.9416882));
+		verifyYieldsNoQuest(new BoundingBox(53.5738493, 9.9408299, 53.5741742, 9.9416882), "2018-03-01");
 	}
 
 	public void test_building_within_relation_area_with_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5054499, 10.1937836, 53.5061231, 10.1943254));
+		verifyYieldsNoQuest(new BoundingBox(53.5054499, 10.1937836, 53.5061231, 10.1943254), "2018-03-01");
 	}
 
-	private void verifyYieldsNoQuest(BoundingBox bbox)
+	private void verifyYieldsNoQuest(BoundingBox bbox, String date)
 	{
+		OverpassMapDataDao o = OsmModule.overpassMapDataDao(OsmModule::overpassMapDataParser);
+		AddHousenumberOldData quest = new AddHousenumberOldData(o, date);
 		MapDataWithGeometryHandler verifier = (element, geometry) ->
 		{
 			fail("Expected zero elements. Element returned: " +

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/quests/add_housenumber/AddHousenumberOldData.java
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/quests/add_housenumber/AddHousenumberOldData.java
@@ -1,0 +1,32 @@
+package de.westnordost.streetcomplete.quests.add_housenumber;
+
+import de.westnordost.osmapi.map.data.BoundingBox;
+import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao;
+import de.westnordost.streetcomplete.quests.housenumber.AddHousenumber;
+
+
+public class AddHousenumberOldData extends AddHousenumber {
+	private String date;
+	AddHousenumberOldData(OverpassMapDataDao overpassServer, String date) {
+		super(overpassServer);
+		this.date = date;
+	}
+
+	private String atticDataRequest(){
+		return "[date:\"" + date + "\"]";
+	}
+
+	protected String getBuildingsWithoutAddressesOverpassQuery(BoundingBox bbox){
+		return atticDataRequest() + ";" + super.getBuildingsWithoutAddressesOverpassQuery(bbox);
+	}
+
+	protected String getFreeFloatingAddressesOverpassQuery(BoundingBox bbox){
+		return atticDataRequest() + super.getFreeFloatingAddressesOverpassQuery(bbox);
+	}
+
+	protected String getNonBuildingAreasWithAddressesQuery(BoundingBox bbox){
+		return atticDataRequest() + super.getNonBuildingAreasWithAddressesQuery(bbox);
+	}
+
+
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumber.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumber.java
@@ -42,7 +42,7 @@ public class AddHousenumber implements OsmElementQuestType
 			"retail|commercial)$'][location!=underground]" + NO_ADDRESS_FILTER;
 
 	/** Query that returns all areas that are not buildings but have addresses */
-	private static String getNonBuildingAreasWithAddresses(BoundingBox bbox)
+	protected String getNonBuildingAreasWithAddressesQuery(BoundingBox bbox)
 	{
 		return OverpassQLUtil.getGlobalOverpassBBox(bbox) +
 			"(way[!building]"+ANY_ADDRESS_FILTER+";rel[!building]"+ANY_ADDRESS_FILTER+";);" +
@@ -51,7 +51,7 @@ public class AddHousenumber implements OsmElementQuestType
 
 	/** Query that returns all buildings that neither have an address node on their outline, nor
 	 *  on itself */
-	private static String getBuildingsWithoutAddressesOverpassQuery(BoundingBox bbox)
+	protected String getBuildingsWithoutAddressesOverpassQuery(BoundingBox bbox)
 	{
 		String bboxFilter = OverpassQLUtil.getOverpassBboxFilter(bbox);
 		return
@@ -67,7 +67,7 @@ public class AddHousenumber implements OsmElementQuestType
 	}
 
 	/** Query that returns all address nodes that are not part of any building outline */
-	private static String getFreeFloatingAddressesOverpassQuery(BoundingBox bbox)
+	protected String getFreeFloatingAddressesOverpassQuery(BoundingBox bbox)
 	{
 		return OverpassQLUtil.getGlobalOverpassBBox(bbox) +
 			"(" +
@@ -171,7 +171,7 @@ public class AddHousenumber implements OsmElementQuestType
 	private ArrayList<Geometry> downloadAreasWithAddresses(BoundingBox bbox)
 	{
 		final ArrayList<Geometry> areas = new ArrayList<>();
-		String query = getNonBuildingAreasWithAddresses(bbox);
+		String query = getNonBuildingAreasWithAddressesQuery(bbox);
 		boolean success = overpassServer.getAndHandleQuota(query, (element, geometry) ->
 		{
 			if(geometry != null)


### PR DESCRIPTION
currently live data is used, as result tests may be broken by OSM edits

note new test_unspecified_building_type_is_excluded - this test fails with the curent OSM data, but it is working for specified point of time

this increases complexity of code, but it should be preferable to tests failing because OSM data changed

I plan on using the same method for unit tests for #920