### PR TITLE
 in tests of Housenumber query use OSM data as it was at specified time

### DIFF
--- a/app/src/androidTest/java/de/westnordost/streetcomplete/quests/add_housenumber/AddHousenumberIntegrationTest.java
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/quests/add_housenumber/AddHousenumberIntegrationTest.java
@@ -11,99 +11,139 @@ import de.westnordost.streetcomplete.quests.housenumber.AddHousenumber;
 
 public class AddHousenumberIntegrationTest extends TestCase
 {
-	private AddHousenumber quest;
-
-	// these tests are dependent on actual data on OSM, which may change of course... so then the
-	// tests need to be adapted... :-/
-
-	@Override public void setUp() throws Exception
-	{
-		super.setUp();
-		OverpassMapDataDao o = OsmModule.overpassMapDataDao(OsmModule::overpassMapDataParser);
-		quest = new AddHousenumber(o);
+	public void test_unspecified_building_type_is_excluded() {
+		//test is using https://www.openstreetmap.org/way/139545168/history, version 3
+		verifyYieldsNoQuest(
+			new BoundingBox(50.06655, 19.93690, 50.06681, 19.93740),
+			"2014-03-01"
+		);
 	}
 
 	public void test_underground_building_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(52.5149999, 13.417933, 52.516198, 13.4183836));
+		verifyYieldsNoQuest(
+			new BoundingBox(52.5149999, 13.417933, 52.516198, 13.4183836),
+			"2018-03-01"
+		);
 	}
 
 	public void test_building_type_that_likely_has_no_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5312195, 9.9804139, 53.531559, 9.9808994));
+		verifyYieldsNoQuest(
+			new BoundingBox(53.5312195, 9.9804139, 53.531559, 9.9808994),
+			"2018-03-01"
+		);
 	}
 
 	/* --------------------------------- buildings with address --------------------------------- */
 
 	public void test_building_with_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(52.3812058, 13.0742659, 52.3815491, 13.0748789));
+		verifyYieldsNoQuest(
+			new BoundingBox(52.3812058, 13.0742659, 52.3815491, 13.0748789),
+			"2018-03-01"
+		);
 	}
 
 	public void test_relation_building_with_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5465806, 9.934811, 53.5473838, 9.9359912));
+		verifyYieldsNoQuest(
+			new BoundingBox(53.5465806, 9.934811, 53.5473838, 9.9359912),
+			"2018-03-01"
+		);
 	}
 
 	/* --------------------------- buildings with address node inside --------------------------- */
 
 	public void test_building_with_address_inside_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(59.9152277, 10.7040524, 59.9155073, 10.7045299));
+		verifyYieldsNoQuest(
+			new BoundingBox(59.9152277, 10.7040524, 59.9155073, 10.7045299),
+			"2018-03-01"
+		);
 	}
 
 	public void test_building_with_address_inside_but_outside_boundingBox_is_excluded_nevertheless()
 	{
-		verifyYieldsNoQuest(new BoundingBox(59.9154105, 10.7041866, 59.9154966, 10.7045299));
+		verifyYieldsNoQuest(
+			new BoundingBox(59.9154105, 10.7041866, 59.9154966, 10.7045299),
+			"2018-03-01"
+		);
 	}
 
 
 	public void test_relation_building_with_address_inside_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(59.9125977,10.7393879,59.9133372,10.740847));
+		verifyYieldsNoQuest(
+			new BoundingBox(59.9125977,10.7393879,59.9133372,10.740847),
+			"2018-03-01"
+		);
 	}
 
 	public void test_relation_building_with_address_inside_but_outside_boundingBox_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(59.9125506,10.7404044,59.9126326,10.7405975));
+		verifyYieldsNoQuest(
+			new BoundingBox(59.9125506,10.7404044,59.9126326,10.7405975),
+			"2018-03-01"
+		);
 	}
 
 	/* ------------------------- buildings with address node on outline ------------------------- */
 
 	public void test_building_with_address_on_outline_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(52.380765, 13.0748677, 52.3809697, 13.075211));
+		verifyYieldsNoQuest(
+			new BoundingBox(52.380765, 13.0748677, 52.3809697, 13.075211),
+			"2018-03-01"
+		);
 	}
 
 	public void test_building_with_address_on_outline_but_outside_boundingBox_is_excluded_nevertheless()
 	{
-		verifyYieldsNoQuest(new BoundingBox(52.3807601, 13.0748811, 52.3808796, 13.0752191));
+		verifyYieldsNoQuest(
+			new BoundingBox(52.3807601, 13.0748811, 52.3808796, 13.0752191),
+			"2018-03-01"
+		);
 	}
 
 	public void test_relation_building_with_address_on_outline_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5546534, 9.9783272, 53.5550996, 9.9797165));
+		verifyYieldsNoQuest(
+			new BoundingBox(53.5546534, 9.9783272, 53.5550996, 9.9797165),
+			"2018-03-01"
+		);
 	}
 
 	public void test_relation_building_with_address_on_outline_but_outside_boundingBox_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5546869,9.9788234,53.5549896,9.9790755));
+		verifyYieldsNoQuest(
+			new BoundingBox(53.5546869,9.9788234,53.5549896,9.9790755),
+			"2018-03-01"
+		);
 	}
 
 	/* --------------------------- buildings within area with address --------------------------- */
 
 	public void test_building_within_area_with_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5738493, 9.9408299, 53.5741742, 9.9416882));
+		verifyYieldsNoQuest(
+			new BoundingBox(53.5738493, 9.9408299, 53.5741742, 9.9416882),
+			"2018-03-01"
+		);
 	}
 
 	public void test_building_within_relation_area_with_address_is_excluded()
 	{
-		verifyYieldsNoQuest(new BoundingBox(53.5054499, 10.1937836, 53.5061231, 10.1943254));
+		verifyYieldsNoQuest(
+			new BoundingBox(53.5054499, 10.1937836, 53.5061231, 10.1943254),
+			"2018-03-01"
+		);
 	}
 
-	private void verifyYieldsNoQuest(BoundingBox bbox)
+	private void verifyYieldsNoQuest(BoundingBox bbox, String date)
 	{
+		OverpassMapDataDao o = OsmModule.overpassOldMapDataDao(OsmModule::overpassMapDataParser, date);
+		AddHousenumber quest = new AddHousenumber(o);
 		MapDataWithGeometryHandler verifier = (element, geometry) ->
 		{
 			fail("Expected zero elements. Element returned: " +

--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmModule.java
@@ -7,6 +7,7 @@ import dagger.Module;
 import dagger.Provides;
 import de.westnordost.osmapi.user.UserDao;
 import de.westnordost.streetcomplete.ApplicationConstants;
+import de.westnordost.streetcomplete.data.osm.download.OverpassOldMapDataDao;
 import de.westnordost.streetcomplete.oauth.OAuthPrefs;
 import de.westnordost.streetcomplete.data.osm.download.ElementGeometryCreator;
 import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao;
@@ -51,6 +52,14 @@ public class OsmModule
 		OsmConnection overpassConnection = new OsmConnection(
 				OVERPASS_API_URL, ApplicationConstants.USER_AGENT, null);
 		return new OverpassMapDataDao(overpassConnection, parserProvider);
+	}
+
+	@Provides public static OverpassOldMapDataDao overpassOldMapDataDao(
+		Provider<OverpassMapDataParser> parserProvider, String date)
+	{
+		OsmConnection overpassConnection = new OsmConnection(
+			OVERPASS_API_URL, ApplicationConstants.USER_AGENT, null);
+		return new OverpassOldMapDataDao(overpassConnection, parserProvider, date);
 	}
 
 	@Provides public static OverpassMapDataParser overpassMapDataParser()

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/OverpassOldMapDataDao.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/OverpassOldMapDataDao.java
@@ -1,0 +1,36 @@
+package de.westnordost.streetcomplete.data.osm.download;
+
+import java.time.LocalDate;
+
+import javax.inject.Provider;
+
+import de.westnordost.osmapi.OsmConnection;
+
+
+public class OverpassOldMapDataDao extends OverpassMapDataDao {
+	private final String date;
+
+	public OverpassOldMapDataDao(OsmConnection osm, Provider<OverpassMapDataParser> parserProvider, String date) {
+		super(osm, parserProvider);
+		this.date = date;
+	}
+
+	private String atticDataRequest(){
+		return "[date:\"" + date + "\"]";
+	}
+
+	private boolean isQueryWithoutSettings(String query){
+		// heurestic, but quite reliable one
+		// non-heurestic would require query parsing what would be unreasonable here
+		return query.toCharArray()[0] != '[';
+	}
+
+	public synchronized void get(final String baseQuery, MapDataWithGeometryHandler handler) {
+		String queryForOldData = atticDataRequest();
+		if(isQueryWithoutSettings(baseQuery)){
+			queryForOldData += ";";
+		}
+		queryForOldData += baseQuery;
+		super.get(queryForOldData, handler);
+	}
+}


### PR DESCRIPTION
#955 with code in Dao (proposed in https://github.com/westnordost/StreetComplete/pull/955#issuecomment-371555019 )

currently live data is used, as result tests may be broken by OSM edits

note new test_unspecified_building_type_is_excluded - this test fails with the curent OSM data, but it is working for specified point of time

this increases complexity of code, but it should be preferable to tests failing because OSM data changed