### PR TITLE
Avoid technical term "form"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="confirmation_discard_negative">"Cancel"</string>
     <string name="action_download">"Scan for Quests here"</string>
     <string name="action_upload">"Upload Answers"</string>
-    <string name="no_changes">"You did not solve the quest"</string>
+    <string name="no_changes">"You did not give any answer"</string>
     <string name="close">"close"</string>
     <string name="download_error">"Error while scanning for quests"</string>
     <string name="upload_error">"Error while uploading answers"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="confirmation_discard_negative">"Cancel"</string>
     <string name="action_download">"Scan for Quests here"</string>
     <string name="action_upload">"Upload Answers"</string>
-    <string name="no_changes">"You left the form empty"</string>
+    <string name="no_changes">"You did not solve the quest"</string>
     <string name="close">"close"</string>
     <string name="download_error">"Error while scanning for quests"</string>
     <string name="upload_error">"Error while uploading answers"</string>


### PR DESCRIPTION
Discovered because of https://github.com/westnordost/StreetComplete/issues/973

I think the user should not be exposed to a technical term as "form".

I first though to name it "You did not choose/select any answer", but that makes no sense in street name or other input quests, so it would need some differentiation in these quests to show "You did not enter any answer".