### PR TITLE
Fix value settings of cycleway quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.java
@@ -133,7 +133,7 @@ public class AddCycleway implements OsmElementQuestType
 			case SIDEWALK: // explicitly marked (often must be used)
 				// https://wiki.openstreetmap.org/wiki/File:Z240GemeinsamerGehundRadweg.jpeg
 				changes.add(cyclewayKey, "track");
-				changes.add("sidewalk:" + side.value + ":bicycle", "designated");
+				changes.add(cyclewayKey + ":segregated", "no");
 				break;
 			case SIDEWALK_OK: // optional use allowed
 				// https://wiki.openstreetmap.org/wiki/File:Z239Z1022-10GehwegRadfahrerFrei.jpeg

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCycleway.java
@@ -130,14 +130,15 @@ public class AddCycleway implements OsmElementQuestType
 				changes.add(cyclewayKey, "lane");
 				changes.addOrModify(cyclewayKey + ":oneway", "no");
 				break;
-			case SIDEWALK:
+			case SIDEWALK: // explicitly marked (often must be used)
 				// https://wiki.openstreetmap.org/wiki/File:Z240GemeinsamerGehundRadweg.jpeg
 				changes.add(cyclewayKey, "track");
-				changes.add(cyclewayKey + ":segregated", "no");
+				changes.add("sidewalk:" + side.value + ":bicycle", "designated");
 				break;
-			case SIDEWALK_OK:
+			case SIDEWALK_OK: // optional use allowed
 				// https://wiki.openstreetmap.org/wiki/File:Z239Z1022-10GehwegRadfahrerFrei.jpeg
 				changes.add(cyclewayKey, "no");
+				changes.add("cycleway:" + side.value, "track"); // if sidewalk is not already mapped
 				changes.add("sidewalk:" + side.value + ":bicycle", "yes");
 				break;
 			case SHARED:


### PR DESCRIPTION
Basically what I explained in https://github.com/westnordost/StreetComplete/issues/978#issuecomment-372656829. (It does not fix the issue though, as it is actually rather about adjsuting the UI.)

\+ I added the fact that it manually tags the sidewalk, if it is not there, otherwise `sidewalk:right:bicycle=yes` may e.g. be there, without a sidewalk tag.

BTW the wiki is not clear about whether to tag `bicycle=yes` for the sidewalk (`sidewalk:right:bicycle=yes`) or for the cycleway (which may be strange when `cycleway=no`), i.e. `cycleway:right:bicycle=yes`.