### PR TITLE
Change overpass-api.de and gnu.org URLs to https 

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.java
@@ -24,7 +24,7 @@ public class AboutFragment extends PreferenceFragmentCompat
 		findPreference("license").setOnPreferenceClickListener( preference ->
 		{
 			Intent browserIntent = new Intent(Intent.ACTION_VIEW,
-					Uri.parse("http://www.gnu.org/licenses/gpl-3.0.html"));
+					Uri.parse("https://www.gnu.org/licenses/gpl-3.0.html"));
 			startActivity(browserIntent);
 			return true;
 		});

--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmModule.java
@@ -27,7 +27,7 @@ public class OsmModule
 {
 	public static final String OSM_API_URL = "https://api.openstreetmap.org/api/0.6/";
 
-	public static final String OVERPASS_API_URL = "http://overpass-api.de/api/";
+	public static final String OVERPASS_API_URL = "https://overpass-api.de/api/";
 
 	/** Returns the osm connection singleton used for all daos with the saved oauth consumer */
 	@Provides @Singleton public static OsmConnection osmConnection(OAuthPrefs oAuth)

--- a/tools/find_popular_sports_by_country.py
+++ b/tools/find_popular_sports_by_country.py
@@ -6,7 +6,7 @@ import sys
 languageCode = sys.argv[1]
 query = "[timeout:3600][out:csv(sport)];(area[\"ISO3166-1\"="+languageCode+"];)->.x;way[leisure=pitch][sport](area.x);out tags;"
 encodedQueryData = str.encode(urllib.parse.urlencode({ "data" : query }))
-response = urllib.request.urlopen("http://overpass-api.de/api/interpreter", encodedQueryData, 3600)
+response = urllib.request.urlopen("https://overpass-api.de/api/interpreter", encodedQueryData, 3600)
 dict = {}
 for line in response:
 	line = line.decode("utf-8").rstrip()


### PR DESCRIPTION
Regarding #63, the `overpass-api.de` and `gnu.org` URLs should probably also be https because they both support it.