### PR TITLE
add names also for insurance shops

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.java
@@ -47,6 +47,9 @@ public class AddPlaceName extends SimpleOverpassQuestType
 			"water_park","miniature_golf", "stadium","marina","bowling_alley", "amusement_arcade",
 			"adult_gaming_centre", "tanning_salon","horse_riding"
 		});
+		put("office", new String[]{
+			"insurance"
+		});
 	}};
 
 	@Inject public AddPlaceName(OverpassMapDataDao overpassServer) { super(overpassServer); }


### PR DESCRIPTION
As it turns out, insurance shops tend to be tagged office=insurance

See https://wiki.openstreetmap.org/w/index.php?title=Tag:shop%3Dinsurance (0,5k) and https://wiki.openstreetmap.org/wiki/Tag:office%3Dinsurance (22k)

It also makes easier to add additional office values