### PR TITLE
add insurance office to opening hours

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.java
@@ -42,6 +42,10 @@ public class AddOpeningHours extends SimpleOverpassQuestType
 				"museum"
 		};
 
+		String[] offices = {
+			"insurance"
+		};
+
 		return " nodes, ways, relations with ( shop and shop !~ no|vacant or" +
 				" amenity ~ " + TextUtils.join("|", amenities) + " or" +
 				" amenity = bicycle_parking and bicycle_parking = building or" +
@@ -49,7 +53,8 @@ public class AddOpeningHours extends SimpleOverpassQuestType
 				" amenity = recycling and recycling_type = centre or" +
 				" tourism ~ " + TextUtils.join("|", tourism) + " or" +
 				" tourism = information and information = office or" +
-				" leisure ~ " + TextUtils.join("|",leisures) + ")" +
+				" leisure ~ " + TextUtils.join("|",leisures) + " or" +
+				" office ~ " + TextUtils.join("|",offices) + ")" +
 				" and !opening_hours and name" +
 				" and (access !~ private|no)"; // exclude ones without access to general public
 	}


### PR DESCRIPTION
As it turns out, insurance shops tend to be tagged office=insurance

See https://wiki.openstreetmap.org/w/index.php?title=Tag:shop%3Dinsurance (0,5k) and https://wiki.openstreetmap.org/wiki/Tag:office%3Dinsurance (22k)

It also makes easier to add further office values