### PR TITLE
add amenity=casino/theatre to wheelchair quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.java
@@ -36,7 +36,7 @@ public class AddWheelchairAccessBusiness extends SimpleOverpassQuestType
 				"courthouse", "embassy", "car_wash", "car_rental",
 				"marketplace", "fuel", "driving_school", "dentist",
 				"doctors", "clinic", "pharmacy", "veterinary",
-				"place_of_worship", "townhall"};
+				"place_of_worship", "townhall", "theatre", "casino"};
 
 		String[] tourism = {
 				"zoo", "aquarium", "theme_park", "gallery",


### PR DESCRIPTION
closes #1081 

I looked through #1081 for new tags where adding makes sense and I found amenity=casino and amenity=theatre

leisure=bird_hide, leisure=wildlife_hide, amenity=language_school were also considered but rejected due to a low usage

amenity=internet_cafe is borderline