### PR TITLE
explain why edit may add oneway=no

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/oneway/AddOneway.java
@@ -136,7 +136,10 @@ public class AddOneway extends AOsmElementQuestType
 	}
 
 	@Override public AbstractQuestAnswerFragment createForm() { return new AddOnewayForm(); }
-	@Override public String getCommitMessage() { return "Add whether this road is a one-way road"; }
+	@Override public String getCommitMessage() {
+		return "Add whether this road is a one-way road," +
+			" this road was marked as likely oneway by improveosm.org";
+	}
 	@Override public int getIcon() { return R.drawable.ic_quest_oneway; }
 	@Override public int getTitle(@NonNull Map<String, String> tags)
 	{


### PR DESCRIPTION
In cases like https://www.openstreetmap.org/way/24164607/history it is not clear at all why somebody added oneway=no. This PR intends to give commit message that explain this.

I was not sure is it preferable to have long line or split string.

tested, for example see https://www.openstreetmap.org/changeset/59715447 