### PR TITLE
smarter ImageList

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ImageListQuestAnswerFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ImageListQuestAnswerFragment.java
@@ -85,7 +85,7 @@ public abstract class ImageListQuestAnswerFragment extends AbstractQuestFormAnsw
 
 	protected int getItemsPerRow()
 	{
-		return 4;
+		return Math.min(4, getItems().length);
 	}
 	/** return -1 for any number. Default: 1 */
     protected int getMaxSelectableItems()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashTypeForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/car_wash_type/AddCarWashTypeForm.java
@@ -31,7 +31,6 @@ public class AddCarWashTypeForm extends ImageListQuestAnswerFragment
 	}
 
 	@Override protected Item[] getItems() { return TYPES; }
-	@Override protected int getItemsPerRow() { return 3; }
 	@Override protected int getMaxSelectableItems() { return 3; }
 
 	@Override public void onIndexSelected(int index)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.java
@@ -13,5 +13,4 @@ public class AddCrossingTypeForm extends ImageListQuestAnswerFragment
     };
 
     @Override protected Item[] getItems() { return TYPES; }
-    @Override protected int getItemsPerRow() { return 3; }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingTypeForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/parking_type/AddParkingTypeForm.java
@@ -13,5 +13,4 @@ public class AddParkingTypeForm extends ImageListQuestAnswerFragment
 	};
 
 	@Override protected Item[] getItems() { return TYPES; }
-	@Override protected int getItemsPerRow() { return 3; }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterialForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/powerpoles_material/AddPowerPolesMaterialForm.java
@@ -13,5 +13,4 @@ public class AddPowerPolesMaterialForm extends ImageListQuestAnswerFragment
 	};
 
 	@Override protected Item[] getItems() { return TYPES; }
-	@Override protected int getItemsPerRow() { return 3; }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingTypeForm.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling/AddRecyclingTypeForm.java
@@ -13,5 +13,4 @@ public class AddRecyclingTypeForm extends ImageListQuestAnswerFragment
 	};
 
 	@Override protected Item[] getItems() { return TYPES; }
-	@Override protected int getItemsPerRow() { return 3; }
 }


### PR DESCRIPTION
This change removes the need to manually specify that entire screen width should be used for answers with low image count.

getItemsPerRow should never (or almost never) be larger than the total count of available items, as it leaves ugly space toward the right

at this moment no quest specifies getItemsPerRow larger that available selection count

this change removes the need to manually specify getItemsPerRow in such cases