### PR TITLE
Add a meaningful user agent to request for map tiles

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/TileHttpHandler.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/TileHttpHandler.java
@@ -3,7 +3,13 @@ package de.westnordost.streetcomplete.tangram;
 import com.mapzen.tangram.HttpHandler;
 
 import java.io.File;
+
+import de.westnordost.streetcomplete.ApplicationConstants;
+import okhttp3.CacheControl;
 import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.internal.Version;
 
 public class TileHttpHandler extends HttpHandler
 {
@@ -23,7 +29,15 @@ public class TileHttpHandler extends HttpHandler
 
 	public boolean onRequest(String url, Callback cb) {
 		if(url != null) url += "?api_key=" + apiKey;
-		return super.onRequest(url, cb);
+		HttpUrl httpUrl = HttpUrl.parse(url);
+		Request.Builder builder = new Request.Builder().url(httpUrl).header("User-Agent", ApplicationConstants.USER_AGENT + " / " + Version.userAgent());
+		CacheControl cacheControl = cachePolicy.apply(httpUrl);
+		if (cacheControl != null) {
+			builder.cacheControl(cacheControl);
+		}
+		Request request = builder.build();
+		okClient.newCall(request).enqueue(cb);
+		return true;
 	}
 
 	public void onCancel(String url) {


### PR DESCRIPTION
This will add a User-Agent headder in the form of
"StreetComplete 7.0 / okhttp/3.5.0" instant of the
default "okhttp/3.5.0" to requests for tiles.

Unfortunately it seems to be necessary to copy the onRequest method from
tangram, as a change in the middle is necessary.

This change is mostly for debugging on the tile Server.