### PR TITLE
Order is important for gradle dependencies repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -10,7 +10,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }


### PR DESCRIPTION
While trying to build streetcomplete with a local debuggable tangram build to test https://github.com/tangrams/tangram-es/issues/1772, I noticed this.

Refer the discussion for the same: https://stackoverflow.com/questions/47164768/failed-to-resolve-com-android-supportappcompat-v727-dependency-error#comment89067724_47165445