### PR TITLE
exclude some weird building from building levels quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.java
@@ -25,8 +25,9 @@ public class AddBuildingLevels extends SimpleOverpassQuestType
 							"school|civic|college|university|public|hospital|kindergarten|transportation|train_station|hotel|"+
 							"retail|commercial|office|warehouse|industrial|manufacture|parking|" +
 							"farm|farm_auxiliary|barn|" +
-		       " and !building:levels and !height and !building:height";
-		// building:height is undocumented, but used the same way as height and currently over 50k times
+			" and !building:levels and !height and !building:height" +
+			// building:height is undocumented, but used the same way as height and currently over 50k times
+			"  and !man_made and location!=underground";
 	}
 
 	public AbstractQuestAnswerFragment createForm()


### PR DESCRIPTION
- underground buildings
- with man_made (for example water tower for steam trains that was correctly tagged with building=transportation)
see https://www.openstreetmap.org/note/1558110