### PR TITLE
experimenting with resurveying API [idea in a pseudocode]

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_cover/AddBikeParkingCover.kt
@@ -9,9 +9,12 @@ import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 class AddBikeParkingCover(o: OverpassMapDataDao) : SimpleOverpassQuestType<Boolean>(o) {
 
     override val tagFilters = """
-        nodes, ways with amenity=bicycle_parking and access !~ private|no and !covered
+        nodes, ways with amenity=bicycle_parking and access !~ private|no
         and bicycle_parking !~ shed|lockers|building
     """
+    //maybe use something more generic, rather than assuming that single tag is always added?
+    override val addedKey = "covered"
+    override val addedValues = {true: "yes", false: "no"}
     override val commitMessage = "Add bicycle parkings cover"
     override val icon = R.drawable.ic_quest_bicycle_parking_cover
 
@@ -19,8 +22,5 @@ class AddBikeParkingCover(o: OverpassMapDataDao) : SimpleOverpassQuestType<Boole
         R.string.quest_bicycleParkingCoveredStatus_title
 
     override fun createForm() = YesNoQuestAnswerFragment()
-
-    override fun applyAnswerTo(answer: Boolean, changes: StringMapChangesBuilder) {
-        changes.add("covered", if (answer) "yes" else "no")
-    }
+    override fun createRepeatedSurveyForm() = YesNoRepeatedQuestAnswerFragment(addedKey, addedValues)
 }


### PR DESCRIPTION
I was updating my fork to merge in Kotlin changes, and during reimplementing my "show `fixme` tags" quest I had a little idea for #1112 

Boolean quests are the simplest ones to generate resurvey quests in a generic way. There is no benefit from showing possible answer and asking it still up to date, like with for example `opening_hours` quest. Though in case of answer that would result in retagging asking "are you sure" would be useful.

So boolean yes/no quests should be easiest to implement in a generic form (rather than handcraft separate version for every single one).

But currently there is no sane way to generate resurvey quest from current classes.

The idea is to modify how boolean quests are specified, so both usual quest and resurvey quest can be generated from the same data.

This PR has pseudocode of how this info may be specified. It looks OK to me, though maybe because it competed with some truly atrocious ideas (like using reflection).

Main problem with current idea is that YesNoRepeatedQuestAnswerFragment would need access to tags of a given OSM element to ask "are you sure" question, and it may be not feasible to pass that information here.