### PR TITLE
New quest/shop names

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -50,6 +50,7 @@ import de.westnordost.streetcomplete.quests.religion.AddReligionToWaysideShrine;
 import de.westnordost.streetcomplete.quests.localized_name.data.PutRoadNameSuggestionsHandler;
 import de.westnordost.streetcomplete.quests.localized_name.data.RoadNameSuggestionsDao;
 import de.westnordost.streetcomplete.quests.segregated.AddCyclewaySegregation;
+import de.westnordost.streetcomplete.quests.shop_name.AddShopName;
 import de.westnordost.streetcomplete.quests.sidewalk.AddSidewalk;
 import de.westnordost.streetcomplete.quests.surface.AddPathSurface;
 import de.westnordost.streetcomplete.quests.tactile_paving.AddTactilePavingBusStop;
@@ -93,6 +94,7 @@ public class QuestModule
 				new AddHousenumber(o),
 				new MarkCompletedHighwayConstruction(o),
 				// new AddPlaceName(o), doesn't make sense as long as the app cannot tell the generic name of elements
+				new AddShopName(o),
 
 				// ↓ 3. useful data that is used by some data consumers
 				new AddRecyclingType(o),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_name/AddShopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_name/AddShopName.kt
@@ -1,0 +1,20 @@
+package de.westnordost.streetcomplete.quests.shop_name
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.SimpleOverpassQuestType
+import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao
+
+class AddShopName(o: OverpassMapDataDao) : SimpleOverpassQuestType<String>(o) {
+    override val tagFilters = """
+        nodes, ways with ((amenity ~ post_office|pharmacy|bank|atm|bureau_de_change) or (shop)) and (!name and noname != yes)
+    """
+    override val commitMessage = "add shop name"
+    override val icon = R.drawable.ic_quest_shop_name
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_shopName_title
+
+    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
+        changes.add("name", answer)
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_name/AddShopName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_name/AddShopName.kt
@@ -4,17 +4,24 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.SimpleOverpassQuestType
 import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
 import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao
+import de.westnordost.streetcomplete.quests.AbstractQuestAnswerFragment
 
-class AddShopName(o: OverpassMapDataDao) : SimpleOverpassQuestType<String>(o) {
+class AddShopName(o: OverpassMapDataDao) : SimpleOverpassQuestType<ShopNameAnswer>(o) {
     override val tagFilters = """
         nodes, ways with ((amenity ~ post_office|pharmacy|bank|atm|bureau_de_change) or (shop)) and (!name and noname != yes)
     """
     override val commitMessage = "add shop name"
     override val icon = R.drawable.ic_quest_shop_name
 
+    // TODO - add the correct name for the shop type (aka integrate with osmfeatures lib)
     override fun getTitle(tags: Map<String, String>) = R.string.quest_shopName_title
 
-    override fun applyAnswerTo(answer: String, changes: StringMapChangesBuilder) {
-        changes.add("name", answer)
+    override fun applyAnswerTo(answer: ShopNameAnswer, changes: StringMapChangesBuilder) {
+        when(answer) {
+            is NoShopNameSign -> changes.add("noname", "yes")
+            is ShopName -> changes.add("name", answer.name)
+        }
     }
+
+    override fun createForm() = AddShopNameForm()
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_name/AddShopNameForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_name/AddShopNameForm.kt
@@ -1,0 +1,41 @@
+package de.westnordost.streetcomplete.quests.shop_name
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
+import de.westnordost.streetcomplete.quests.OtherAnswer
+import de.westnordost.streetcomplete.util.TextChangedWatcher
+import kotlinx.android.synthetic.main.quest_placename.*
+
+class AddShopNameForm : AbstractQuestFormAnswerFragment<ShopNameAnswer>() {
+
+    override val contentLayoutResId = R.layout.quest_shopname
+
+    override val otherAnswers = listOf(
+        OtherAnswer(R.string.quest_name_answer_noName) { confirmNoName() }
+    )
+
+    private val placeName get() = nameInput?.text?.toString().orEmpty().trim()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        nameInput.addTextChangedListener(TextChangedWatcher { checkIsFormComplete() })
+    }
+
+    override fun onClickOk() {
+        applyAnswer(ShopName(placeName))
+    }
+
+    private fun confirmNoName() {
+        AlertDialog.Builder(activity!!)
+                .setTitle(R.string.quest_name_answer_noName_confirmation_title)
+                .setPositiveButton(R.string.quest_name_noName_confirmation_positive) { _, _ -> applyAnswer(NoShopNameSign) }
+                .setNegativeButton(R.string.quest_generic_confirmation_no, null)
+                .show()
+    }
+
+    override fun isFormComplete() = placeName.isNotEmpty()
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/shop_name/ShopNameAnswer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/shop_name/ShopNameAnswer.kt
@@ -1,0 +1,6 @@
+package de.westnordost.streetcomplete.quests.shop_name
+
+sealed class ShopNameAnswer
+
+data class ShopName(val name:String) : ShopNameAnswer()
+object NoShopNameSign : ShopNameAnswer()

--- a/app/src/main/res/drawable/ic_quest_shop_name.xml
+++ b/app/src/main/res/drawable/ic_quest_shop_name.xml
@@ -1,0 +1,27 @@
+    <vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="128dp"
+        android:height="128dp"
+        android:viewportWidth="34"
+        android:viewportHeight="34">
+    <path
+        android:pathData="m33.87,16.93c0,9.35 -7.58,16.93 -16.93,16.93C7.58,33.87 0,26.29 0,16.93 0,7.58 7.58,0 16.93,0c9.35,0 16.93,7.58 16.93,16.93"
+        android:fillColor="#c8c4b7"/>
+    <path
+        android:pathData="M16.96,9.5 L8.49,17.96L8.46,17.96v9.53h5.99v-7.39h5.01v7.39h6v-9.53h-0.04z"
+        android:fillAlpha="0.2"
+        android:fillColor="#000"/>
+    <path
+        android:pathData="M6.47,17.17 L17.05,6.59 27.63,17.17"
+        android:strokeLineCap="square"
+        android:strokeColor="#000"
+        android:strokeWidth="3"
+        android:strokeAlpha="0.19607801"/>
+    <path
+        android:pathData="M16.96,8.44 L8.49,16.9L8.46,16.9v9.53h5.99v-7.39h5.01v7.39h6v-9.53h-0.04z"
+        android:fillColor="#fff"/>
+    <path
+        android:pathData="M6.47,15.98 L17.05,5.4 27.64,15.98"
+        android:strokeLineCap="square"
+        android:strokeColor="#c84747"
+        android:strokeWidth="3"/>
+</vector>

--- a/app/src/main/res/layout/quest_shopname.xml
+++ b/app/src/main/res/layout/quest_shopname.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<EditText
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/nameInput"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,7 +113,10 @@
     <string name="quest_roofShape_select_one">"Select one:"</string>
     <string name="quest_roofShape_show_more">"Show more…"</string>
     <string name="quest_roofShape_answer_many">"It has several different shapes"</string>
-    <string name="quest_shopName_title">"What is the name of this shop?"</string>
+    <string name="quest_shopName_title">"What is the name of shop %s?"</string>
+    <string name="quest_shopName_answer_noName">"It has no name…"</string>
+    <string name="quest_shopName_answer_noName_confirmation_title">"Really no name?"</string>
+    <string name="quest_shopName_noName_confirmation_positive">"Yes, no name"</string>
     <string name="quest_sport_title">"What sport is played here?"</string>
     <string name="quest_sport_answer_multi">"Not any specific sport"</string>
     <string name="quest_sport_soccer">"Soccer"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="quest_roofShape_select_one">"Select one:"</string>
     <string name="quest_roofShape_show_more">"Show more…"</string>
     <string name="quest_roofShape_answer_many">"It has several different shapes"</string>
+    <string name="quest_shopName_title">"What is the name of this shop?"</string>
     <string name="quest_sport_title">"What sport is played here?"</string>
     <string name="quest_sport_answer_multi">"Not any specific sport"</string>
     <string name="quest_sport_soccer">"Soccer"</string>

--- a/app/src/test/java/de/westnordost/streetcomplete/quests/ShopNameTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/quests/ShopNameTest.kt
@@ -1,0 +1,31 @@
+package de.westnordost.streetcomplete.quests
+
+import de.westnordost.streetcomplete.data.osm.changes.StringMapEntryAdd
+import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao
+import de.westnordost.streetcomplete.quests.shop_name.AddShopName
+import de.westnordost.streetcomplete.quests.shop_name.NoShopNameSign
+import de.westnordost.streetcomplete.quests.shop_name.ShopName
+import org.junit.Test
+
+import org.mockito.Mockito.mock
+
+class ShopNameTest {
+
+    private val questType = AddShopName(mock(OverpassMapDataDao::class.java))
+
+    @Test
+    fun `apply no name answer`() {
+        questType.verifyAnswer(
+            NoShopNameSign,
+            StringMapEntryAdd("noname", "yes")
+        )
+    }
+
+    @Test fun `apply name answer`() {
+        questType.verifyAnswer(
+            ShopName("Shop name here"),
+            StringMapEntryAdd("name", "Shop name here")
+        )
+    }
+
+}


### PR DESCRIPTION
so, I've managed to hack together a first start on the shop names quest. This is my first time writing Kotlin, and what's here is from looking at the StreetComplete source and deducing how to put a quest  together, so it's probably full of rookie mistakes and I am totally open to any and all feedback on how to improve this.

Some questions have arisen:
- is there anything I've missed?
- what's the best way to look at this quest within the app?
- where do the StreetComplete icons come from? They look rather awesome, and so I am inspired to match the quality, but I have absolutely no clue about generating Android vector drawables. Is there an existing editable source for the icons I can start from for example? (Note: for the sake of getting something up and running I have copied an existing icon)
- how do I integrate this with the osmnames / osmfeatures library (actually, I forked the repo a while back and have just rebased the changes onto my branch, so I can see there is some fresh work underway to integrate this, so I might be able to answer this myself, but any pointers are gratefully received).