### PR TITLE
increase bus stop name importance

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -94,6 +94,7 @@ public class QuestModule
 				new AddRoadName(o, roadNameSuggestionsDao, putRoadNameSuggestionsHandler),
 				new AddPlaceName(o, featureDictionaryFuture),
 				new AddOneway(o, trafficFlowSegmentsDao, trafficFlowDao),
+				new AddBusStopName(o),
 				new AddIsBuildingUnderground(o), //to avoid asking AddHousenumber and other for underground buildings
 				new AddHousenumber(o),
 				new MarkCompletedHighwayConstruction(o),
@@ -122,7 +123,6 @@ public class QuestModule
 				new AddParkingAccess(o),
 				new AddParkingFee(o),
 				new AddMotorcycleParkingCapacity(o),
-				new AddBusStopName(o),
 				new AddPathSurface(o),
 				new AddTracktype(o),
 				new AddBikeParkingType(o), // used by OsmAnd


### PR DESCRIPTION
also used by many data consumers

-----

BTW, I plan to propose some other changes in quest order. One of repeated misleading impressions of StreetComplete is "it asks only about street surface what is boring" and I plan on proposing some changes in default order to reduce this issue.

But I spotted surprisingly low position of bus stop name and decided to submit it separately.