### PR TITLE
promote some quests before surface quest 

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -101,14 +101,14 @@ public class QuestModule
 
 				// ↓ 3. useful data that is used by some data consumers
 				new AddRecyclingType(o),
+				new AddReligionToPlaceOfWorship(o), // icon on maps are different
+				new AddSport(o),
 				new AddRoadSurface(o),
 				new AddMaxSpeed(o), // should best be after road surface because it excludes unpaved roads
 				new AddMaxHeight(o),
 				new AddRailwayCrossingBarrier(o), // useful for routing
-				new AddReligionToPlaceOfWorship(o), // icon on maps are different
 				new AddPostboxCollectionTimes(o),
 				new AddOpeningHours(o),
-				new AddSport(o),
 				new AddBikeParkingCapacity(o), // cycle map layer on osm.org
 				new AddOrchardProduce(o),
 				new AddCycleway(o),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -113,7 +113,7 @@ public class QuestModule
 				new AddOrchardProduce(o),
 				new AddCycleway(o),
 				new AddSidewalk(o),
-				new AddProhibitedForPedestrians(o),
+				new AddProhibitedForPedestrians(o), // uses info from AddSidewalk quest, should be after it
 				new AddCrossingType(o),
 				new AddBuildingLevels(o),
 				new AddBusStopShelter(o), // at least OsmAnd


### PR DESCRIPTION
according to my attempt at UX testing, some spotted reviews and interviewing some users
large number of surface quests may overhelm users, confuse them and result in failure
to discover other available quests

These two quests are more interesting to a mapper, except rare situation
will not be as repetitive as surface quest and except rare situation their number
of occurences will be far more limited.

This is intended to provide more interesting mapping for users.

Main negative is that in some places no quests of this type will be available, so
app will waste two Overpass requests and do not get quests

-----

My work on this pull request and UX testing was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)