### PR TITLE
Quest prority - reordering the list

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -98,10 +98,11 @@ public class QuestModule
 				new AddIsBuildingUnderground(o), //to avoid asking AddHousenumber and other for underground buildings
 				new AddHousenumber(o),
 				new MarkCompletedHighwayConstruction(o),
+				new AddReligionToPlaceOfWorship(o), // icons on maps are different - OSM Carto, mapy.cz, OsmAnd, Sputnik etc
+				new AddParkingAccess(o), //OSM Carto, mapy.cz, OSMand, Sputnik etc
 
 				// ↓ 3. useful data that is used by some data consumers
 				new AddRecyclingType(o),
-				new AddReligionToPlaceOfWorship(o), // icon on maps are different
 				new AddSport(o),
 				new AddRoadSurface(o),
 				new AddMaxSpeed(o), // should best be after road surface because it excludes unpaved roads
@@ -120,7 +121,6 @@ public class QuestModule
 				new AddVegetarian(o),
 				new AddVegan(o),
 				new AddInternetAccess(o),
-				new AddParkingAccess(o),
 				new AddParkingFee(o),
 				new AddMotorcycleParkingCapacity(o),
 				new AddPathSurface(o),

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -126,8 +126,10 @@ public class QuestModule
 				new AddPathSurface(o),
 				new AddTracktype(o),
 				new AddBikeParkingType(o), // used by OsmAnd
-				new AddWheelChairAccessToilets(o), // used by wheelmap, MAPS.ME
+				new AddWheelChairAccessToilets(o), // used by wheelmap, OsmAnd, MAPS.ME
 				new AddPlaygroundAccess(o), //late as in many areas all needed access=private is already mapped
+				new AddWheelchairAccessBusiness(o), // used by wheelmap, OsmAnd, MAPS.ME
+				new AddToiletAvailability(o), //OSM Carto, shown in OsmAnd descriptions
 
 				// ↓ 4. definitely shown as errors in QA tools
 
@@ -137,15 +139,16 @@ public class QuestModule
 				// ↓ 6. may be shown as possibly missing in QA tools
 
 				// ↓ 7. data useful for only a specific use case
+				new AddWayLit(o), //  used by OsmAnd if "Street lighting" is enabled. (Configure map, Map rendering, Details)
+				new AddToiletsFee(o), // used by OsmAnd in the object description
+				new AddBabyChangingTable(o), // used by OsmAnd in the object description
+				new AddBikeParkingCover(o), // used by OsmAnd in the object description
 				new AddTrafficSignalsSound(o),
 				new AddRoofShape(o),
 				new AddWheelChairAccessPublicTransport(o),
 				new AddWheelchairAccessOutside(o),
 				new AddTactilePavingBusStop(o),
 				new AddTactilePavingCrosswalk(o),
-				new AddWayLit(o),
-				new AddWheelchairAccessBusiness(o),
-				new AddToiletAvailability(o),
 				new AddBridgeStructure(o),
 				new AddReligionToWaysideShrine(o),
 				new AddCyclewaySegregation(o),
@@ -153,10 +156,7 @@ public class QuestModule
 
 				// ↓ 8. defined in the wiki, but not really used by anyone yet. Just collected for
 				//      the sake of mapping it in case it makes sense later
-				new AddBikeParkingCover(o),
 				new AddMotorcycleParkingCover(o),
-				new AddToiletsFee(o),
-				new AddBabyChangingTable(o),
 				new AddFireHydrantType(o),
 				new AddParkingType(o),
 				new AddPowerPolesMaterial(o),


### PR DESCRIPTION
This is final part of proposed priority changes. I found two quests that are both more important and more interesting than surface quest for roads and increased their importance.

Also, noticed that some quests with actually used data are below quests that add data that is currently unused.

-------

This should be a final PR in series, main goal was to bump quests both more interesting and more important than surface quest a bit higher. Now I see nothing fitting.


-----

My work on this pull request and UX testing was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)