### PR TITLE
Add hints for opening hours differing by day of week [WIP]

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/Context.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/Context.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.ktx
 import android.content.Context
 import android.widget.Toast
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
 
 fun Context.toast(text: CharSequence, duration: Int = Toast.LENGTH_SHORT) {
     Toast.makeText(this, text, duration).show()
@@ -10,4 +11,11 @@ fun Context.toast(text: CharSequence, duration: Int = Toast.LENGTH_SHORT) {
 
 fun Context.toast(@StringRes resId: Int, duration: Int = Toast.LENGTH_SHORT) {
     Toast.makeText(this, resId, duration).show()
+}
+
+fun Context.showHint(@StringRes messageId: Int) {
+    AlertDialog.Builder(this)
+            .setMessage(messageId)
+            .setPositiveButton(android.R.string.ok, null)
+            .show()
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
@@ -15,6 +15,7 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.PopupMenu
+import androidx.annotation.StringRes
 
 import java.lang.ref.WeakReference
 import java.util.Locale

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevelsForm.kt
@@ -8,6 +8,7 @@ import javax.inject.Inject
 
 import de.westnordost.streetcomplete.Injector
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.showHint
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.quests.LastPickedValuesStore
 import de.westnordost.streetcomplete.quests.OtherAnswer
@@ -20,7 +21,7 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
     override val contentLayoutResId = R.layout.quest_building_levels
 
     override val otherAnswers = listOf(
-        OtherAnswer(R.string.quest_buildingLevels_answer_multipleLevels) { showMultipleLevelsHint() }
+        OtherAnswer(R.string.quest_buildingLevels_answer_multipleLevels) { activity?.showHint(R.string.quest_buildingLevels_answer_description) }
     )
 
     private val levels get() = levelsInput?.text?.toString().orEmpty().trim()
@@ -67,14 +68,6 @@ class AddBuildingLevelsForm : AbstractQuestFormAnswerFragment<BuildingLevelsAnsw
         favs.add(javaClass.simpleName,
             listOfNotNull(buildingLevels, roofLevels).joinToString("#"), max = 1)
         applyAnswer(BuildingLevelsAnswer(buildingLevels, roofLevels))
-    }
-
-    private fun showMultipleLevelsHint() {
-        activity?.let { AlertDialog.Builder(it)
-            .setMessage(R.string.quest_buildingLevels_answer_description)
-            .setPositiveButton(android.R.string.ok, null)
-            .show()
-        }
     }
 
     override fun isFormComplete() = !levels.isEmpty()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingTypeForm.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.showHint
 import de.westnordost.streetcomplete.quests.AGroupedImageListQuestAnswerFragment
 import de.westnordost.streetcomplete.quests.OtherAnswer
 import de.westnordost.streetcomplete.quests.building_type.BuildingType.*
@@ -11,7 +12,7 @@ import de.westnordost.streetcomplete.quests.building_type.BuildingType.*
 class AddBuildingTypeForm : AGroupedImageListQuestAnswerFragment<String,String>() {
 
     override val otherAnswers = listOf(
-        OtherAnswer(R.string.quest_buildingType_answer_multiple_types) { showMultipleTypesHint() },
+        OtherAnswer(R.string.quest_buildingType_answer_multiple_types) { activity?.showHint(R.string.quest_buildingType_answer_multiple_types_description) },
         OtherAnswer(R.string.quest_buildingType_answer_construction_site) { applyAnswer("construction") }
     )
 
@@ -33,13 +34,5 @@ class AddBuildingTypeForm : AGroupedImageListQuestAnswerFragment<String,String>(
 
     override fun onClickOk(value: String) {
         applyAnswer(value)
-    }
-
-    private fun showMultipleTypesHint() {
-        activity?.let { AlertDialog.Builder(it)
-            .setMessage(R.string.quest_buildingType_answer_multiple_types_description)
-            .setPositiveButton(android.R.string.ok, null)
-            .show()
-        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumberForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumberForm.kt
@@ -13,6 +13,7 @@ import android.widget.EditText
 import androidx.core.content.getSystemService
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.showHint
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.quests.OtherAnswer
 import de.westnordost.streetcomplete.quests.building_type.BuildingType
@@ -25,7 +26,7 @@ class AddHousenumberForm : AbstractQuestFormAnswerFragment<HousenumberAnswer>() 
     override val otherAnswers = listOf(
         OtherAnswer(R.string.quest_address_answer_no_housenumber) { onNoHouseNumber() },
         OtherAnswer(R.string.quest_address_answer_house_name) { switchToHouseName() },
-        OtherAnswer(R.string.quest_housenumber_multiple_numbers) { showMultipleNumbersHint() }
+        OtherAnswer(R.string.quest_housenumber_multiple_numbers) { activity?.showHint(R.string.quest_housenumber_multiple_numbers_description) }
     )
 
     private var houseNumberInput: EditText? = null
@@ -61,14 +62,6 @@ class AddHousenumberForm : AbstractQuestFormAnswerFragment<HousenumberAnswer>() 
     private fun switchToHouseName() {
         isHousename = true
         setLayout(R.layout.quest_housename)
-    }
-
-    private fun showMultipleNumbersHint() {
-        activity?.let { AlertDialog.Builder(it)
-            .setMessage(R.string.quest_housenumber_multiple_numbers_description)
-            .setPositiveButton(android.R.string.ok, null)
-            .show()
-        }
     }
 
     private fun onNoHouseNumber() {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursForm.kt
@@ -23,6 +23,7 @@ import de.westnordost.streetcomplete.util.Serializer
 
 import android.view.Menu.NONE
 import androidx.recyclerview.widget.RecyclerView
+import de.westnordost.streetcomplete.ktx.showHint
 import de.westnordost.streetcomplete.quests.OtherAnswer
 import de.westnordost.streetcomplete.ktx.toObject
 import kotlinx.android.synthetic.main.quest_opening_hours.*

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHoursForm.kt
@@ -36,7 +36,8 @@ class AddOpeningHoursForm : AbstractQuestFormAnswerFragment<OpeningHoursAnswer>(
         OtherAnswer(R.string.quest_openingHours_no_sign) { confirmNoSign() },
         OtherAnswer(R.string.quest_openingHours_answer_no_regular_opening_hours) { showInputCommentDialog() },
         OtherAnswer(R.string.quest_openingHours_answer_247) { showConfirm24_7Dialog() },
-        OtherAnswer(R.string.quest_openingHours_answer_seasonal_opening_hours) { openingHoursAdapter.changeToMonthsMode() }
+        OtherAnswer(R.string.quest_openingHours_answer_seasonal_opening_hours) { openingHoursAdapter.changeToMonthsMode() },
+        OtherAnswer(R.string.quest_openingHours_answer_differs_by_day_of_week) { activity?.showHint(R.string.quest_openingHours_differs_by_day_of_week) }
     )
 
     private lateinit var openingHoursAdapter: AddOpeningHoursAdapter

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="quest_openingHours_chooseMonthsTitle">"Select months"</string>
     <string name="quest_openingHours_chooseWeekdaysTitle">"Select group of weekdays with the same opening hours"</string>
     <string name="quest_openingHours_24_7_confirmation">"In other words, is it open any time, every day?"</string>
-    <string name="quest_openingHours_differs_by_day_of_week">You can use the \"ADD OPENING HOURS\" button multiple times, adding separate groups of days with the same opening hours.</string>
+    <string name="quest_openingHours_differs_by_day_of_week">You can use the \"ADD OPENING HOURS\" button multiple times, adding separate groups of days with the same opening hours every time.</string>
     <string name="quest_openingHours_answer_differs_by_day_of_week">Differs by day of week…</string>
     <string name="quest_noteDiscussion_title">"Can you contribute anything to this note?"</string>
     <string name="quest_noteDiscussion_no">"No, hide"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,8 @@
     <string name="quest_openingHours_chooseMonthsTitle">"Select months"</string>
     <string name="quest_openingHours_chooseWeekdaysTitle">"Select weekdays"</string>
     <string name="quest_openingHours_24_7_confirmation">"In other words, is it open any time, every day?"</string>
+    <string name="quest_openingHours_differs_by_day_of_week">Use the \"ADD OPENING HOURS\" button.\nSelect group of days with the same opening hours.\nFill opening hours.\nUse again \"ADD OPENING HOURS\"\nFill opening hours for the next group of days.\n\nRepeat if needed\n\nOnce completed use \"OK\" button.</string>
+    <string name="quest_openingHours_answer_differs_by_day_of_week">Differs by day of week…</string>
     <string name="quest_noteDiscussion_title">"Can you contribute anything to this note?"</string>
     <string name="quest_noteDiscussion_no">"No, hide"</string>
     <string name="quest_noteDiscussion_comment2">"— %1$s, %2$s"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,9 +49,9 @@
     <string name="quest_openingHours_add_hours">"Add hours"</string>
     <string name="quest_openingHours_add_weekdays">"Add weekdays"</string>
     <string name="quest_openingHours_chooseMonthsTitle">"Select months"</string>
-    <string name="quest_openingHours_chooseWeekdaysTitle">"Select weekdays"</string>
+    <string name="quest_openingHours_chooseWeekdaysTitle">"Select group of weekdays with the same opening hours"</string>
     <string name="quest_openingHours_24_7_confirmation">"In other words, is it open any time, every day?"</string>
-    <string name="quest_openingHours_differs_by_day_of_week">Use the \"ADD OPENING HOURS\" button.\nSelect group of days with the same opening hours.\nFill opening hours.\nUse again \"ADD OPENING HOURS\"\nFill opening hours for the next group of days.\n\nRepeat if needed\n\nOnce completed use \"OK\" button.</string>
+    <string name="quest_openingHours_differs_by_day_of_week">You can use the \"ADD OPENING HOURS\" button multiple times, adding separate groups of days with the same opening hours.</string>
     <string name="quest_openingHours_answer_differs_by_day_of_week">Differs by day of week…</string>
     <string name="quest_noteDiscussion_title">"Can you contribute anything to this note?"</string>
     <string name="quest_noteDiscussion_no">"No, hide"</string>


### PR DESCRIPTION
I made a small UX test. Three people attempted opening hours hours quest for object where opening hours differed by day. All three required hint to proceed, they were either confused from start or selected all days when shop was open and failed to answer it.

In comparison one person who had trouble with building level quest was happy with explanation in "differ per building part" hint that she found by herself.

This hint is not solving the entire problem. There are still people stuck after selecting days but before realizing what should be done, that never tried using "other answers...". But it should help at least some of people.

-----

I also added `showHint` to `AbstractQuestAnswerFragment.kt` to reduce code duplication.

-----

My work on this pull request and UX testing was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)