### PR TITLE
do not attack new user with request to register/login so early

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
@@ -496,6 +496,7 @@ public class MainActivity extends AppCompatActivity implements
 	@UiThread private void requestOAuthorized()
 	{
 		if(dontShowRequestAuthorizationAgain) return;
+		if(answersCounter.waitingForUpload() <= 5) return;
 
 		View inner = LayoutInflater.from(this).inflate(
 				R.layout.dialog_authorize_now, null, false);

--- a/app/src/main/java/de/westnordost/streetcomplete/statistics/AnswersCounter.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/statistics/AnswersCounter.java
@@ -86,6 +86,10 @@ public class AnswersCounter
 		updateTexts();
 	}
 
+	public Integer waitingForUpload(){
+		return unsynced;
+	}
+
 	@SuppressLint("StaticFieldLeak") public void update()
 	{
 		new AsyncTask<Void, Void, Void>()


### PR DESCRIPTION
During UX testing it turned out that starting is really confusing for an user actually new to OSM

She needed to (everything listed in full, as it is intended to solve a part of a larger problem)

- install application
- grant permissions (works great)
- wait for quests to load (this is not obvious that it is necessary, #178 exists with a good idea for solving this)
- figure out app interface
- figure out interface of the first quest (for bonus points - first one turned out to be opening hours quest, that maybe should be hidden for green users with <10 stars)
- solved quest
- immediately login window appeared
- it was necessary to register, with entire form filling + ToS + mail confirmation drudgery
- after registration app was stuck waiting for login, it was necessary to cancel this and request login again, login spinner initially refused to act (not sure is it user/phone error or an app bug)
- now it was necessary to login

She told me that if she would be trying app on her own there would be no chance at all to pass through all this hoops at the very start.

All of that to solve first quest. I am pretty sure that delaying nag screen about registration would be a good idea as it would not harm more experienced users, they will make more than 7 edits and login a bit later. It would mean that edits by people who made six edits and less are lost, but they would probably be lost on going through registration process.

And it would help some newbie users that would be too confused by a current process, but would be OK with more gradual ramping up.


-----

Implementation itself is more suspect as current AnswersCounter is about interface only, in fact it is giving answer reduced by one as it is increased only after animation completes (so login window is triggered on 7th edit).

It can be solved by having separate `unsynced` and `displayedUnsynced`, ignoring disrepancy or not mixing displayed statistics and statistics infuencing UI behavior (I have some additional ideas for special handling for newbie mappers).

-----

My work on this pull request and UX testing was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)