### PR TITLE
rework settings layout

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,6 @@
     <string name="quest_sport_ice_hockey">"Ice hockey"</string>
     <string name="quest_sport_netball">"Netball"</string>
     <string name="quest_sport_rugby">"Rugby"</string>
-    <string name="pref_category_cache">"Cache"</string>
     <string name="pref_title_sync">"Auto-sync"</string>
     <string name="map_btn_zoom_out">"Zoom out"</string>
     <string name="map_btn_zoom_in">"Zoom in"</string>
@@ -643,7 +642,6 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_sidewalk_value_yes">sidewalk</string>
     <string name="quest_sidewalk_value_no">no sidewalk</string>
     <string name="quest_accessible_for_pedestrians_title_prohibited">Are pedestrians prohibited from walking on this road here?</string>
-    <string name="pref_category_theme">Theme</string>
     <string name="pref_title_theme_select">Select theme</string>
     <string name="theme_automatic">Auto</string>
     <string name="theme_light">Light</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -27,7 +27,55 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="@string/pref_category_cache">
+        android:key="display"
+        android:title="@string/pref_category_display">
+
+        <Preference
+            android:key="quests"
+            android:title="@string/pref_title_quests"
+            android:widgetLayout="@layout/widget_image_next"
+            />
+
+        <SwitchPreference
+            android:key="display.nonQuestionNotes"
+            android:title="@string/pref_title_show_notes_not_phrased_as_questions"
+            android:summaryOn="@string/pref_summaryOn_show_notes_not_phrased_as_questions"
+            android:summaryOff="@string/pref_summaryOff_show_notes_not_phrased_as_questions"
+            android:persistent="true"
+            />
+
+        <SwitchPreference
+            android:key="display.keepScreenOn"
+            android:title="@string/pref_title_keep_screen_on"
+            android:persistent="true"
+            />
+
+        <ListPreference
+            android:key="theme.select"
+            android:title="@string/pref_title_theme_select"
+            android:summary="%s"
+            android:defaultValue="AUTO"
+            android:entries="@array/pref_entries_theme_select"
+            android:entryValues="@array/pref_entryvalues_theme_select"
+            android:persistent="true"
+            />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="advanced"
+        android:title="@string/pref_category_advanced"
+        >
+
+        <Preference
+            android:key="quests.invalidation"
+            android:title="@string/pref_title_quests_invalidation"
+            android:summary="@string/pref_title_quests_invalidation_summary"
+            />
+
+        <Preference
+            android:key="quests.restore.hidden"
+            android:title="@string/pref_title_quests_restore_hidden"
+            />
 
         <de.westnordost.streetcomplete.settings.NumberPickerPreference
             android:key="map.tilecache"
@@ -43,67 +91,6 @@
             android:positiveButtonText="@android:string/ok"
             android:negativeButtonText="@android:string/cancel"
             />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:key="display"
-        android:title="@string/pref_category_display">
-
-        <SwitchPreference
-            android:key="display.keepScreenOn"
-            android:title="@string/pref_title_keep_screen_on"
-            android:persistent="true"
-            />
-
-        <SwitchPreference
-            android:key="display.nonQuestionNotes"
-            android:title="@string/pref_title_show_notes_not_phrased_as_questions"
-            android:summaryOn="@string/pref_summaryOn_show_notes_not_phrased_as_questions"
-            android:summaryOff="@string/pref_summaryOff_show_notes_not_phrased_as_questions"
-            android:persistent="true"
-            />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:key="theme"
-        android:title="@string/pref_category_theme">
-
-        <ListPreference
-            android:key="theme.select"
-            android:title="@string/pref_title_theme_select"
-            android:summary="%s"
-            android:defaultValue="AUTO"
-            android:entries="@array/pref_entries_theme_select"
-            android:entryValues="@array/pref_entryvalues_theme_select"
-            android:persistent="true"
-            />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:key="advanced"
-        android:title="@string/pref_category_advanced"
-        >
-
-        <Preference
-            android:key="quests"
-            android:title="@string/pref_title_quests"
-            android:widgetLayout="@layout/widget_image_next"
-            />
-
-        <Preference
-            android:key="quests.invalidation"
-            android:title="@string/pref_title_quests_invalidation"
-            android:summary="@string/pref_title_quests_invalidation_summary"
-            />
-
-        <Preference
-            android:key="quests.restore.hidden"
-            android:title="@string/pref_title_quests_restore_hidden"
-            />
-
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
I reworked setting layout based on what people actually want to change. My testing has a small sample size. But for now basically all people were interested in quest list - at least viewing it. Some also in changing. Some even started given unprompted advice to make it far more prominent.

So it is moved higher while some settings much less likely/useful to change were downgraded into advanced settings.

in UX testing multiple people that reached settings menu declared that quest selection should not be hidden in advanced settings

I also shown quest list to some people after UX testing session and reactions where mix of
- why I was not aware that X is disabled? I am very interested in this topic.
- it is interesting (about specific quest)
- it is amazing (about quest variety)
- I really like icon X (often for the underground buildings)
- I was not aware that there are some many question types
- it should be displayed on first startup (I am pretty sure that it would have more negatives than positives).

Also some people using SC declared that it should be less hidden.

So it is promoted higher, out of advanced settings, visible without scrolling settings list.

I also downgraded cache size into advanced, in normal operation there is no need to change it.

I removed separate single element theme and cache group as unnecessary.

-----

Why I keep writing books in commit messages? Is full story behind such change is useful. And more useful than something like "reworked settings moving ones more likely to be used to the top, quest list was especially wanted according to the UX testing"? I somehow made XXL commit message again, I am planning to strongly avoid doing it with the next one, but maybe it is useful.

-----

My work on this pull request and UX testing was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)