### PR TITLE
warn on abandoning partially filled quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCyclewayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bikeway/AddCyclewayForm.kt
@@ -148,6 +148,8 @@ class AddCyclewayForm : AbstractQuestFormAnswerFragment<CyclewayAnswer>() {
         if (isDefiningBothSides) leftSide != null && rightSide != null
         else                     leftSide != null || rightSide != null
 
+    override fun isRejectingClose() = leftSide != null || rightSide != null
+
     private fun showCyclewaySelectionDialog(isRight: Boolean) {
         val recyclerView = RecyclerView(activity!!)
         recyclerView.layoutParams = RecyclerView.LayoutParams(MATCH_PARENT, MATCH_PARENT)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalkForm.kt
@@ -73,6 +73,8 @@ class AddSidewalkForm : AbstractQuestFormAnswerFragment<SidewalkAnswer>() {
 
     override fun isFormComplete() = leftSide != null && rightSide != null
 
+    override fun isRejectingClose() = leftSide != null || rightSide != null
+
     private fun showSidewalkSelectionDialog(isRight: Boolean) {
         val recyclerView = RecyclerView(activity!!)
         recyclerView.layoutParams = RecyclerView.LayoutParams(MATCH_PARENT, MATCH_PARENT)


### PR DESCRIPTION
gives second line of feedback in case of a confused user described in e5f30dc88b84b72d79817422e25e110d0023cb30

affects sidewalk and cycleway quest

-----

My work on this pull request and UX testing was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)