### PR TITLE
explain that photos are useful [ready for review]

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
@@ -15,7 +15,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 
 import java.io.File
 import java.io.FileOutputStream
@@ -26,6 +25,8 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osmnotes.AttachPhotoUtils
 
 import android.app.Activity.RESULT_OK
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
 import de.westnordost.streetcomplete.ApplicationConstants.ATTACH_PHOTO_MAXWIDTH
 import de.westnordost.streetcomplete.ApplicationConstants.ATTACH_PHOTO_QUALITY
 import de.westnordost.streetcomplete.ktx.toast
@@ -33,7 +34,9 @@ import kotlinx.android.synthetic.main.fragment_attach_photo.*
 
 class AttachPhotoFragment : Fragment() {
 
-    val imagePaths: List<String> get() = noteImageAdapter.list
+    val imagePaths: List<String> get() = noteImageAdapter.list;
+    private var photosListView : RecyclerView? = null;
+    private var hintView : TextView? = null;
 
     private var currentImagePath: String? = null
 
@@ -45,8 +48,19 @@ class AttachPhotoFragment : Fragment() {
         if (!activity!!.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
             view.visibility = View.GONE
         }
-
+        photosListView = view.findViewById(R.id.gridView)
+        hintView = view.findViewById(R.id.photosAreUsefulExplanation)
         return view
+    }
+
+    private fun updateHintVisibility(){
+        if (imagePaths.isEmpty()) {
+            photosListView?.visibility = View.GONE;
+            hintView?.visibility = View.VISIBLE;
+        } else {
+            photosListView?.visibility = View.VISIBLE;
+            hintView?.visibility = View.GONE;
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -70,6 +84,7 @@ class AttachPhotoFragment : Fragment() {
             false
         )
         gridView.adapter = noteImageAdapter
+        updateHintVisibility()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -126,6 +141,7 @@ class AttachPhotoFragment : Fragment() {
             }
             currentImagePath = null
         }
+        updateHintVisibility()
     }
 
     private fun removeCurrentImage() {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/note_discussion/AttachPhotoFragment.kt
@@ -25,11 +25,13 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osmnotes.AttachPhotoUtils
 
 import android.app.Activity.RESULT_OK
+import android.database.DataSetObserver
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import de.westnordost.streetcomplete.ApplicationConstants.ATTACH_PHOTO_MAXWIDTH
 import de.westnordost.streetcomplete.ApplicationConstants.ATTACH_PHOTO_QUALITY
 import de.westnordost.streetcomplete.ktx.toast
+import de.westnordost.streetcomplete.util.AdapterDataChangedWatcher
 import kotlinx.android.synthetic.main.fragment_attach_photo.*
 
 class AttachPhotoFragment : Fragment() {
@@ -84,6 +86,7 @@ class AttachPhotoFragment : Fragment() {
             false
         )
         gridView.adapter = noteImageAdapter
+        noteImageAdapter.registerAdapterDataObserver(AdapterDataChangedWatcher { updateHintVisibility() })
         updateHintVisibility()
     }
 
@@ -141,7 +144,6 @@ class AttachPhotoFragment : Fragment() {
             }
             currentImagePath = null
         }
-        updateHintVisibility()
     }
 
     private fun removeCurrentImage() {

--- a/app/src/main/res/layout/fragment_attach_photo.xml
+++ b/app/src/main/res/layout/fragment_attach_photo.xml
@@ -21,7 +21,7 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/gridView"
-        android:layout_toEndOf="@id/photosAreUsefulExplanation"
+        android:layout_toEndOf="@id/takePhotoButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"/>

--- a/app/src/main/res/layout/fragment_attach_photo.xml
+++ b/app/src/main/res/layout/fragment_attach_photo.xml
@@ -11,9 +11,17 @@
         android:contentDescription="@string/quest_leave_new_note_photo"
         android:layout_centerVertical="true"/>
 
+    <TextView
+        android:id="@+id/photosAreUsefulExplanation"
+        android:layout_toEndOf="@id/takePhotoButton"
+        android:text="@string/quest_leave_new_note_photos_are_useful"
+        android:layout_width="120dp"
+        android:layout_height="64dp"
+        android:layout_centerVertical="true"/>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/gridView"
-        android:layout_toEndOf="@id/takePhotoButton"
+        android:layout_toEndOf="@id/photosAreUsefulExplanation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"/>

--- a/app/src/main/res/layout/fragment_attach_photo.xml
+++ b/app/src/main/res/layout/fragment_attach_photo.xml
@@ -15,8 +15,8 @@
         android:id="@+id/photosAreUsefulExplanation"
         android:layout_toEndOf="@id/takePhotoButton"
         android:text="@string/quest_leave_new_note_photos_are_useful"
-        android:layout_width="120dp"
-        android:layout_height="64dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_centerVertical="true"/>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>
     <string name="quest_leave_new_note_photo_delete_title">Do you want to delete this picture?</string>
+    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the report much more useful.</string>
     <string name="quest_streetName_title">"What is the name of this road?"</string>
     <string name="quest_streetName_description">"as written on the street sign, abbreviations are expanded:"</string>
     <string name="quest_streetName_answer_noName_confirmation_description">"Sometimes the street sign is only at one end of the street. Also, note that there may not be extra street signs for side streets that belong to a bigger street. Usually, any street with houses has a name."</string>
@@ -659,5 +660,4 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_ferry_pedestrian_title">Does this ferry route transport pedestrians?</string>
     <string name="quest_ferry_motor_vehicle_name_title">Does %s transport motor vehicles?</string>
     <string name="quest_ferry_motor_vehicle_title">Does this ferry route transport motor vehicles?</string>
-    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the report much more useful.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -659,5 +659,5 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_ferry_pedestrian_title">Does this ferry route transport pedestrians?</string>
     <string name="quest_ferry_motor_vehicle_name_title">Does %s transport motor vehicles?</string>
     <string name="quest_ferry_motor_vehicle_title">Does this ferry route transport motor vehicles?</string>
-    <string name="quest_leave_new_note_photos_are_useful">Adding photo will make the report much more useful.</string>
+    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the report much more useful.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>
     <string name="quest_leave_new_note_photo_delete_title">Do you want to delete this picture?</string>
-    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the report much more useful.</string>
+    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the note much more useful.</string>
     <string name="quest_streetName_title">"What is the name of this road?"</string>
     <string name="quest_streetName_description">"as written on the street sign, abbreviations are expanded:"</string>
     <string name="quest_streetName_answer_noName_confirmation_description">"Sometimes the street sign is only at one end of the street. Also, note that there may not be extra street signs for side streets that belong to a bigger street. Usually, any street with houses has a name."</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -659,4 +659,5 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_ferry_pedestrian_title">Does this ferry route transport pedestrians?</string>
     <string name="quest_ferry_motor_vehicle_name_title">Does %s transport motor vehicles?</string>
     <string name="quest_ferry_motor_vehicle_title">Does this ferry route transport motor vehicles?</string>
+    <string name="quest_leave_new_note_photos_are_useful">Adding photo will make the report much more useful.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>
     <string name="quest_leave_new_note_photo_delete_title">Do you want to delete this picture?</string>
-    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the note much more useful.</string>
+    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the note much more useful. Identifiers of location and direction like address plaque are very valuable.</string>
     <string name="quest_streetName_title">"What is the name of this road?"</string>
     <string name="quest_streetName_description">"as written on the street sign, abbreviations are expanded:"</string>
     <string name="quest_streetName_answer_noName_confirmation_description">"Sometimes the street sign is only at one end of the street. Also, note that there may not be extra street signs for side streets that belong to a bigger street. Usually, any street with houses has a name."</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>
     <string name="quest_leave_new_note_photo_delete_title">Do you want to delete this picture?</string>
-    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the note much more useful. Identifiers of location and direction like address plaque are very valuable.</string>
+    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the note much more useful. Identifiers of location and direction like address plaques are very valuable.</string>
     <string name="quest_streetName_title">"What is the name of this road?"</string>
     <string name="quest_streetName_description">"as written on the street sign, abbreviations are expanded:"</string>
     <string name="quest_streetName_answer_noName_confirmation_description">"Sometimes the street sign is only at one end of the street. Also, note that there may not be extra street signs for side streets that belong to a bigger street. Usually, any street with houses has a name."</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>
     <string name="quest_leave_new_note_photo_delete_title">Do you want to delete this picture?</string>
-    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the note much more useful. Identifiers of location and direction like address plaques are very valuable.</string>
+    <string name="quest_leave_new_note_photos_are_useful">Adding a photo will make the note much more useful.</string>
     <string name="quest_streetName_title">"What is the name of this road?"</string>
     <string name="quest_streetName_description">"as written on the street sign, abbreviations are expanded:"</string>
     <string name="quest_streetName_answer_noName_confirmation_description">"Sometimes the street sign is only at one end of the street. Also, note that there may not be extra street signs for side streets that belong to a bigger street. Usually, any street with houses has a name."</string>


### PR DESCRIPTION
During testing it turned out that people were strongly underestimating usefulness of photos in notes for other mappers. This attempts to counteract this.

Note that text field is poor - I want it at once to use as much as horizontal space as possible and prefer to use vertical spa and make it work independent of a text length (translations). I am unsure how to solve this and created PR to check whatever solution is obvious.