### PR TITLE
reorganize settings again - degrade autosync

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="oauth_cancelled">"Authorization canceled"</string>
     <string name="oauth_failed_permissions">"Authorization failed: All listed permissions need to be granted"</string>
     <string name="title_activity_settings">"Settings"</string>
-    <string name="pref_category_communication">"Communication"</string>
+    <string name="pref_category_account">Account</string>
     <string name="pref_category_display">"Display"</string>
     <string name="pref_title_authorization">"Authorize OSM access"</string>
     <string name="pref_title_authorized_username_summary">"Authorized account: %s"</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -3,18 +3,8 @@
                   xmlns:custom="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
-        android:key="communication"
-        android:title="@string/pref_category_communication">
-
-        <ListPreference
-            android:key="autosync"
-            android:title="@string/pref_title_sync"
-            android:summary="%s"
-            android:defaultValue="ON"
-            android:entries="@array/pref_entries_autosync"
-            android:entryValues="@array/pref_entryvalues_autosync"
-            android:persistent="true"
-            />
+        android:key="account"
+        android:title="@string/pref_category_account">
 
         <Preference
             android:key="oauth"
@@ -66,15 +56,25 @@
         android:title="@string/pref_category_advanced"
         >
 
-        <Preference
-            android:key="quests.invalidation"
-            android:title="@string/pref_title_quests_invalidation"
-            android:summary="@string/pref_title_quests_invalidation_summary"
+        <ListPreference
+            android:key="overpass_url"
+            android:title="@string/pref_title_overpass_url_select"
+            android:summary="@string/pref_title_overpass_url_info"
+            android:defaultValue="https://overpass-api.de/api/"
+            android:entries="@array/pref_overpass_url_select"
+            android:entryValues="@array/pref_overpass_url_select"
+            android:persistent="true"
             />
 
         <Preference
             android:key="quests.restore.hidden"
             android:title="@string/pref_title_quests_restore_hidden"
+            />
+
+        <Preference
+            android:key="quests.invalidation"
+            android:title="@string/pref_title_quests_invalidation"
+            android:summary="@string/pref_title_quests_invalidation_summary"
             />
 
         <de.westnordost.streetcomplete.settings.NumberPickerPreference
@@ -91,17 +91,16 @@
             android:positiveButtonText="@android:string/ok"
             android:negativeButtonText="@android:string/cancel"
             />
-      
+
         <ListPreference
-            android:key="overpass_url"
-            android:title="@string/pref_title_overpass_url_select"
-            android:summary="@string/pref_title_overpass_url_info"
-            android:defaultValue="https://overpass-api.de/api/"
-            android:entries="@array/pref_overpass_url_select"
-            android:entryValues="@array/pref_overpass_url_select"
+            android:key="autosync"
+            android:title="@string/pref_title_sync"
+            android:summary="%s"
+            android:defaultValue="ON"
+            android:entries="@array/pref_entries_autosync"
+            android:entryValues="@array/pref_entryvalues_autosync"
             android:persistent="true"
             />
-      
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
autosync is not an important option, and enabling it may be problematic - for example one of the complaints in English reviews on Google Play is from person confused by interface that used to be default and now appears only with autosync disabled

autosync also requires people to manually sync what is increasing chance of unsynced data, or data synced very late

In addition advanced setting were moved around - moving to top ones that are more likely to be usefully used

-----

My work on this pull request and UX testing was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)