### PR TITLE
reduce chance that quest marker disappears as user zooms in [not ready for review]

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
@@ -385,7 +385,7 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 	}
 */
 
-	private Long getQuestPriority(Quest quest){
+	private int getQuestPriority(Quest quest){
 		// priority is decided by
 		// - primarily by quest type to allow quest prioritization
 		// - for quests of the same type - influenced by quest id,
@@ -399,7 +399,8 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 		order *= freeValuesForEachQuest;
 
 		// quest ID is used to add values unique to each quest to make ordering consistent
-		long hopefullyUniqueValueForQuest = quest.getId() % freeValuesForEachQuest;
+		// freeValuesForEachQuest is an int, so % freeValuesForEachQuest will fit into int
+		int hopefullyUniqueValueForQuest = (int) (quest.getId() % freeValuesForEachQuest);
 
 		return order + hopefullyUniqueValueForQuest;
 	}

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
@@ -396,7 +396,7 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 		Integer order = questTypeOrder.get(quest.getType());
 		if(order == null) order = 0;
 		int freeValuesForEachQuest = Integer.MAX_VALUE / questTypeOrder.size();
-		order = order * freeValuesForEachQuest;
+		order *= freeValuesForEachQuest;
 
 		// quest ID is used to add values unique to each quest to make ordering consistent
 		long hopefullyUniqueValueForQuest = quest.getId() % freeValuesForEachQuest;

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
@@ -385,6 +385,25 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 	}
 */
 
+	protected Long questPriority(Quest quest){
+		// priority is decided by
+		// - primarily by quest type to allow quest prioritization
+		// - for quests of the same type - influenced by quest id,
+		//   this is done to reduce chance that as user zoom in a quest disappears,
+		//   especially in case where disappearing quest is one that user selected to solve
+
+		// main priority part - values fit into Integer, but with as large steps as possible
+		Integer order = questTypeOrder.get(quest.getType());
+		if(order == null) order = 0;
+		Integer freeValuesForEachQuest = Integer.MAX_VALUE / questTypeOrder.size();
+		order = order * freeValuesForEachQuest;
+
+		// quest ID is used to add values unique to each quest to make ordering consistent
+		long hopefullyUniqueValueForQuest = quest.getId() % freeValuesForEachQuest;
+
+		return order + hopefullyUniqueValueForQuest;
+	}
+
 	@UiThread
 	public void addQuests(Iterable quests, QuestGroup group)
 	{
@@ -405,9 +424,6 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 			}
 
 			String questIconName = getActivity().getResources().getResourceEntryName(quest.getType().getIcon());
-
-			Integer order = questTypeOrder.get(quest.getType());
-			if(order == null) order = 0;
 
 			LatLon[] positions = quest.getMarkerLocations();
 
@@ -434,7 +450,7 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 				geoJson.append("\",\"");
 				geoJson.append("order");
 				geoJson.append("\":\"");
-				geoJson.append(order);
+				geoJson.append(questPriority(quest));
 				geoJson.append("\"}}");
 			}
 		}

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
@@ -395,7 +395,7 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 		// main priority part - values fit into Integer, but with as large steps as possible
 		Integer order = questTypeOrder.get(quest.getType());
 		if(order == null) order = 0;
-		Integer freeValuesForEachQuest = Integer.MAX_VALUE / questTypeOrder.size();
+		int freeValuesForEachQuest = Integer.MAX_VALUE / questTypeOrder.size();
 		order = order * freeValuesForEachQuest;
 
 		// quest ID is used to add values unique to each quest to make ordering consistent

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/QuestsMapFragment.java
@@ -385,7 +385,7 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 	}
 */
 
-	protected Long questPriority(Quest quest){
+	private Long getQuestPriority(Quest quest){
 		// priority is decided by
 		// - primarily by quest type to allow quest prioritization
 		// - for quests of the same type - influenced by quest id,
@@ -450,7 +450,7 @@ public class QuestsMapFragment extends MapFragment implements TouchInput.TapResp
 				geoJson.append("\",\"");
 				geoJson.append("order");
 				geoJson.append("\":\"");
-				geoJson.append(questPriority(quest));
+				geoJson.append(getQuestPriority(quest));
 				geoJson.append("\"}}");
 			}
 		}


### PR DESCRIPTION
this is a bit weird/surprising/confusing behavior and in general
is undesirable and has no benefit

it wss especially weird in cases where marker of currently solved
quest was not visible and blocked by other nearby quest of the same
type

note that zooming in still may cause quest to disappear in
following cases
 - low importance quest is displayed because nearby important
   blocked medium importance quest. On zooming in medium
   medium importance quest may become unlocked and
   block formerly visible low importance quest
 - quests have the same iD after % operation

-----

In this case noone actually complained/noticed during testing except myself.

-----

My work on this pull request and UX testing was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)