### PR TITLE
stop timeouting after 45 seconds [ready for review]

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmModule.java
@@ -64,18 +64,16 @@ public class OsmModule
 		return new OsmMapDataFactory();
 	}
 
-	public static int defaultOverpassTimeoutInMiliseconds(){
-		// see https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#timeout:
-		// default value is 180 seconds
-		// give additional 4 seconds to get and process refusal from Overpass
-		// or maybe a bit late response rather than trigger timeout exception
-		return (180 + 4) * 1000;
-	}
+	// see https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#timeout:
+	// default value is 180 seconds
+	// give additional 4 seconds to get and process refusal from Overpass
+	// or maybe a bit late response rather than trigger timeout exception
+	private static int OVERPASS_QUERY_TIMEOUT_IN_MILISECONDS = (180 + 4) * 1000;
 
 	@Provides public static OverpassMapDataDao overpassMapDataDao(
 			Provider<OverpassMapDataParser> parserProvider, SharedPreferences prefs)
 	{
-		Integer timeout = defaultOverpassTimeoutInMiliseconds();
+		Integer timeout = OVERPASS_QUERY_TIMEOUT_IN_MILISECONDS;
 		OsmConnection overpassConnection = new OsmConnection(
 			prefs.getString(Prefs.OVERPASS_URL, OVERPASS_API_WITH_ATTIC_DATA_URL), ApplicationConstants.USER_AGENT, null, timeout);
 		return new OverpassMapDataDao(overpassConnection, parserProvider);
@@ -84,7 +82,7 @@ public class OsmModule
 	@Provides public static OverpassOldMapDataDao overpassOldMapDataDao(
 		Provider<OverpassMapDataParser> parserProvider, String date)
 	{
-		Integer timeout = defaultOverpassTimeoutInMiliseconds();
+		Integer timeout = OVERPASS_QUERY_TIMEOUT_IN_MILISECONDS;
 		OsmConnection overpassConnection = new OsmConnection(
 			OVERPASS_API_WITH_ATTIC_DATA_URL, ApplicationConstants.USER_AGENT, null, timeout);
 		return new OverpassOldMapDataDao(overpassConnection, parserProvider, date);

--- a/app/src/main/java/de/westnordost/streetcomplete/data/OsmModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/OsmModule.java
@@ -64,19 +64,29 @@ public class OsmModule
 		return new OsmMapDataFactory();
 	}
 
+	public static int defaultOverpassTimeoutInMiliseconds(){
+		// see https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#timeout:
+		// default value is 180 seconds
+		// give additional 4 seconds to get and process refusal from Overpass
+		// or maybe a bit late response rather than trigger timeout exception
+		return (180 + 4) * 1000;
+	}
+
 	@Provides public static OverpassMapDataDao overpassMapDataDao(
 			Provider<OverpassMapDataParser> parserProvider, SharedPreferences prefs)
 	{
+		Integer timeout = defaultOverpassTimeoutInMiliseconds();
 		OsmConnection overpassConnection = new OsmConnection(
-			prefs.getString(Prefs.OVERPASS_URL, OVERPASS_API_WITH_ATTIC_DATA_URL), ApplicationConstants.USER_AGENT, null);
+			prefs.getString(Prefs.OVERPASS_URL, OVERPASS_API_WITH_ATTIC_DATA_URL), ApplicationConstants.USER_AGENT, null, timeout);
 		return new OverpassMapDataDao(overpassConnection, parserProvider);
 	}
 
 	@Provides public static OverpassOldMapDataDao overpassOldMapDataDao(
 		Provider<OverpassMapDataParser> parserProvider, String date)
 	{
+		Integer timeout = defaultOverpassTimeoutInMiliseconds();
 		OsmConnection overpassConnection = new OsmConnection(
-			OVERPASS_API_WITH_ATTIC_DATA_URL, ApplicationConstants.USER_AGENT, null);
+			OVERPASS_API_WITH_ATTIC_DATA_URL, ApplicationConstants.USER_AGENT, null, timeout);
 		return new OverpassOldMapDataDao(overpassConnection, parserProvider, date);
 	}
 


### PR DESCRIPTION
default overpass timeout is 180 seconds
should fix #1010, may help with #1466

Construction tests started failing in a new way, but quest download already works nicer

> AddBusStopName: Added 0 new and removed 0 already resolved quests. (Total: 0) in 82s

> AddPlaceName: Added 41 new and removed 0 already resolved quests. (Total: 41) in 95s

logged in my testing would be a timeout errors before this change (BTW, I wonder is AddBusStopName unreasonably expensive or is it just an unlucky call)