### PR TITLE
handle operator as name for postboxes

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/QuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/QuestType.kt
@@ -14,6 +14,8 @@ interface QuestType<T> {
      * if it is not disabled by default */
     val defaultDisabledMessage: Int get() = 0
 
+    val nameGivingTags: List<String> get() = listOf("name", "brand")
+
     /** returns the dialog in which the user can add the data */
     fun createForm(): AbstractQuestAnswerFragment<T>
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
@@ -12,21 +12,19 @@ import java.util.*
 import java.util.concurrent.FutureTask
 
 fun Resources.getQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): String {
-    val name = getElementName(element, configuration.locale, featureDictionaryFuture)
+    val name = getElementName(questType, element, configuration.locale, featureDictionaryFuture)
     return getString(getQuestTitleResId(questType, element), name)
 }
 
 fun Resources.getHtmlQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): Spanned {
-    val name = getElementName(element, configuration.locale, featureDictionaryFuture)
+    val name = getElementName(questType, element, configuration.locale, featureDictionaryFuture)
     val spanName = if (name != null) "<i>" + Html.escapeHtml(name) + "</i>" else null
     return Html.fromHtml(getString(getQuestTitleResId(questType, element), spanName))
 }
 
-private fun getElementName(element: Element?, locale: Locale, featureDictionaryFuture: FutureTask<FeatureDictionary>?) =
-
+private fun getElementName(questType: QuestType<*>, element: Element?, locale: Locale, featureDictionaryFuture: FutureTask<FeatureDictionary>?) =
     element?.tags?.let { tags ->
-        tags["name"] ?:
-        tags["brand"] ?:
+        tags[questType.nameGivingTags.firstOrNull { tags.containsKey(it) }] ?:
         featureDictionaryFuture?.get()?.let { it.byTags(tags).forLocale(locale).find()?.firstOrNull()?.name }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -35,7 +35,16 @@ class AddPostboxCollectionTimes(o: OverpassMapDataDao) : SimpleOverpassQuestType
         // apparently mostly not in Latin America and in Arabic world and unknown in Africa
     )
 
-    override fun getTitle(tags: Map<String, String>) = R.string.quest_postboxCollectionTimes_title
+    override val nameGivingTags: List<String>
+        get() {
+            return listOf("name", "brand", "operator")
+        }
+
+    override fun getTitle(tags: Map<String, String>): Int {
+        val hasName = tags.containsKey("name") || tags.containsKey("brand") || tags.containsKey("operator")
+        return if (hasName) R.string.quest_postboxCollectionTimes_name_title
+        else         R.string.quest_postboxCollectionTimes_title
+    }
 
     override fun createForm() = AddCollectionTimesForm()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,6 +497,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_bicycle_parking_type_title">What type of bicycle parking is this?</string>
     <string name="quest_cycleway_value_suggestion_lane">bicycle suggestion lane</string>
     <string name="quest_postboxCollectionTimes_title">What are the collection times of this postbox?</string>
+    <string name="quest_postboxCollectionTimes_name_title">What are the collection times of this %s postbox?</string>
     <string name="quest_collectionTimes_add_times">Add collection time</string>
     <string name="quest_collectionTimes_answer_no_times_specified">No times specified</string>
     <string name="quest_construction_road_title">Is this road completed?</string>


### PR DESCRIPTION
also, allow each quest to give its own list of name giving tags

fixes #1473

---

I also thought about adding this data to rather to OsmElementQuestType but it would require type checking on use, as getQuestTitle has parameter of `QuestType<*>` type.

I tested that it works on name quest for school with `operator` tag (no displayed), post box with `operator` tag (displayed), post box, without operator tag, note quest, one way quest, road name quest.


-----

My work on this pull request was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)