### PR TITLE
 ask about name of amenity=ferry_terminal + improvements to a comments

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -29,13 +29,13 @@ class AddPlaceName(
                 "townhall", "prison", "courthouse", "embassy", "police", "fire_station", "ranger_station",                              // civic
                 "bank", "bureau_de_change", "money_transfer", "post_office", "library", "marketplace", "internet_cafe",                 // commercial
                 "community_centre", "social_facility", "nursing_home", "childcare", "retirement_home", "social_centre", "youth_centre", // social
-                "car_wash", "car_rental", "boat_rental", "fuel",                                                                        // car stuff
+                "car_wash", "car_rental", "boat_rental", "fuel",                                                                        // transport
                 "dentist", "doctors", "clinic", "pharmacy", "hospital",                                                                 // health care
                 "place_of_worship", "monastery",                                                                                        // religious
                 "kindergarten", "school", "college", "university", "research_institute",                                                // education
                 "driving_school", "dive_centre", "language_school", "music_school",                                                     // learning
                 "casino", "brothel", "gambling", "love_hotel", "stripclub",                                                             // bad stuff
-                "animal_boarding", "animal_shelter", "animal_breeding", "veterinary"
+                "animal_boarding", "animal_shelter", "animal_breeding", "veterinary"                                                    // animals
             ),
             "tourism" to arrayOf(
                 "attraction", "zoo", "aquarium", "theme_park", "gallery", "museum",                                          // attractions

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -39,7 +39,7 @@ class AddPlaceName(
             ),
             "tourism" to arrayOf(
                 "attraction", "zoo", "aquarium", "theme_park", "gallery", "museum",                                          // attractions
-                "hotel", "guest_house", "motel", "hostel", "alpine_hut", "apartment", "resort", "camp_site", "caravan_site"  // accomodations
+                "hotel", "guest_house", "motel", "hostel", "alpine_hut", "apartment", "resort", "camp_site", "caravan_site"  // accommodations
                 // and tourism=information, see above
             ),
             "leisure" to arrayOf(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -29,7 +29,7 @@ class AddPlaceName(
                 "townhall", "prison", "courthouse", "embassy", "police", "fire_station", "ranger_station",                              // civic
                 "bank", "bureau_de_change", "money_transfer", "post_office", "library", "marketplace", "internet_cafe",                 // commercial
                 "community_centre", "social_facility", "nursing_home", "childcare", "retirement_home", "social_centre", "youth_centre", // social
-                "car_wash", "car_rental", "boat_rental", "fuel",                                                                        // transport
+                "car_wash", "car_rental", "boat_rental", "fuel", "ferry_terminal",                                                      // transport
                 "dentist", "doctors", "clinic", "pharmacy", "hospital",                                                                 // health care
                 "place_of_worship", "monastery",                                                                                        // religious
                 "kindergarten", "school", "college", "university", "research_institute",                                                // education


### PR DESCRIPTION
I have no strong feelings about names of `amenity=ferry_terminal` - I am equally fine with deciding that mandatory `name`/`noname` for all of them is pointless and request change (maybe PR) in the Vespucci.

http://overpass-turbo.eu/s/KB8 (ones without name)
https://taginfo.openstreetmap.org/tags/amenity=ferry_terminal#combinations (60% have name tagged)
https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dferry_terminal

---

Note: not a grant-based PR.