### PR TITLE
make res/country_metada less confusing

### DIFF
--- a/res/country_metadata/additionalStreetsignLanguages.yml
+++ b/res/country_metadata/additionalStreetsignLanguages.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # A mapping of additional languages that one can expect to find on a street sign that are not official languages
 # Sources:
 # https://wiki.openstreetmap.org/wiki/Multilingual_names

--- a/res/country_metadata/additionalValidHousenumberRegex.yml
+++ b/res/country_metadata/additionalValidHousenumberRegex.yml
@@ -1,2 +1,3 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 ES: s/n
 FR: \p{N}{1,4}\sbis

--- a/res/country_metadata/firstDayOfWorkweek.yml
+++ b/res/country_metadata/firstDayOfWorkweek.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # the first day in a workweek (not necessarily the first day of the week in a calendar)
 # Source: https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world (retrieved 2016-10-27)
 default: Mo

--- a/res/country_metadata/isAdvisorySpeedLimitKnown.yml
+++ b/res/country_metadata/isAdvisorySpeedLimitKnown.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # Sources:
 # https://en.wikipedia.org/wiki/advisory_speed_limit
 # https://en.wikipedia.org/wiki/Comparison_of_European_road_signs

--- a/res/country_metadata/isLeftHandTraffic.yml
+++ b/res/country_metadata/isLeftHandTraffic.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # Source: https://en.wikipedia.org/wiki/List_of_countries_with_left-hand_traffic 15/09/2017
 default: false
 AI: true

--- a/res/country_metadata/isLivingStreetKnown.yml
+++ b/res/country_metadata/isLivingStreetKnown.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # Sources:
 # https://en.wikipedia.org/wiki/Living_street
 # https://en.wikipedia.org/wiki/Comparison_of_European_road_signs

--- a/res/country_metadata/isSlowZoneKnown.yml
+++ b/res/country_metadata/isSlowZoneKnown.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # see https://en.wikipedia.org/wiki/30_km/h_zone and extend
 default: false
 # European countries

--- a/res/country_metadata/measurementSystem.yml
+++ b/res/country_metadata/measurementSystem.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # Sources:
 # https://en.wikipedia.org/wiki/Metrication#Overview
 # https://en.wikipedia.org/wiki/Imperial_units#Current_use

--- a/res/country_metadata/mobileCountryCode.yml
+++ b/res/country_metadata/mobileCountryCode.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # sources: https://en.wikipedia.org/wiki/Mobile_country_code
 # Overseas and unincorporated territories and other regions that are already
 # part of another ISO 3166-alpha2 code are commented out

--- a/res/country_metadata/officialLanguages.yml
+++ b/res/country_metadata/officialLanguages.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # list of languages spoken and written by country
 # ordered by:
 # 1. statewide official (used by government)

--- a/res/country_metadata/orchardProduces.yml
+++ b/res/country_metadata/orchardProduces.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # list of most produced/cultivated crops/fruits in the world
 # source: Food and Agriculture Organization of the United Nations, http://www.fao.org/faostat/en/#data/QC
 # created/parsed by script: https://github.com/rugk/crops-parser

--- a/res/country_metadata/popularReligions.yml
+++ b/res/country_metadata/popularReligions.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # religions that should be shown first before the order defined in the form.
 # no total order required. Just mention the religions that should show within the first few entries
 default: []

--- a/res/country_metadata/popularSports.yml
+++ b/res/country_metadata/popularSports.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # sports that should be shown first before the order defined in the form.
 # no total order required. Just mention the sports that should show within the first few entries
 default: []

--- a/res/country_metadata/regularShoppingDays.yml
+++ b/res/country_metadata/regularShoppingDays.yml
@@ -1,3 +1,4 @@
+# use app/generateCountryMetadata.py to generate files used by StreetComplete
 # how many days shops usually have regular opening hours per week. According to
 # https://en.wikipedia.org/wiki/Shopping_hours the norm for shopping days is rather MO-SA (=6 days)
 default: 6


### PR DESCRIPTION
I again forgot that running app/generateCountryMetadata.py is necessary

-----

My work on this pull request was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849) (discovered and fixed as part of making #1467)