### PR TITLE
Reproducible builds

### DIFF
--- a/app/generateCountryMetadata.py
+++ b/app/generateCountryMetadata.py
@@ -16,7 +16,7 @@ for filename in sorted(os.listdir(sourceDir)):
 	if filename.endswith(".yml"):
 		basename = os.path.splitext(filename)[0]
 		with open(sourceDir + filename, 'r', encoding='utf8') as file:
-			data = yaml.load(file.read());
+			data = yaml.load(file.read())
 			for key, value in data.items():
 				targetFileName = targetDir + key + ".yml"
 				

--- a/app/generateCountryMetadata.py
+++ b/app/generateCountryMetadata.py
@@ -21,9 +21,9 @@ for filename in sorted(os.listdir(sourceDir)):
 				targetFileName = targetDir + key + ".yml"
 				
 				if os.path.isfile(targetFileName):
-					targetFile = open(targetFileName, "a", encoding='utf8')
+					targetFile = open(targetFileName, "a", encoding='utf8', newline='\r\n')
 				else:
-					targetFile = open(targetFileName, "w", encoding='utf8')
+					targetFile = open(targetFileName, "w", encoding='utf8', newline='\r\n')
 					targetFile.write("# "+comment+"\n")
 				
 				dump = yaml.safe_dump(value)


### PR DESCRIPTION
keep newlines the same across systems to avoid spurious changes

currently running `generateCountryMetadata.py` on Linux will change all newlines to `\n` making much larger diff than necessary
this will use Windows style newlines also when writing to file on Linux (the same as currently committed in repo)

-----

My work on this pull request was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849) (discovered and fixed as part of making #1467)