### PR TITLE
use collection that preserves insertion order

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/NodeWayMap.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/NodeWayMap.java
@@ -1,15 +1,15 @@
 package de.westnordost.streetcomplete.data.osm.download;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /** Knows which vertices connect which ways. T is the identifier of a vertex */
 public class NodeWayMap<T>
 {
-	private final Map<T, List<List<T>>> wayEndpoints = new HashMap<>();
+	private final Map<T, List<List<T>>> wayEndpoints = new LinkedHashMap<>();
 
 	public NodeWayMap(List<List<T>> ways)
 	{


### PR DESCRIPTION
HashMap was causing elements in relation to not be ordered in the original order
fixes (on my computer) issue discussed in https://github.com/westnordost/StreetComplete/commit/e877c0cce9e5cbbf849576f37b1b248221288cc7

I still worry that also sets may be unordered - are used for example in https://github.com/westnordost/StreetComplete/blob/3244b26320754907a44bfa622338293d39318db9/app/src/main/java/de/westnordost/streetcomplete/data/osm/download/NodeWayMap.java#L41