### PR TITLE
improve AUTHORS.md file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,8 @@ Code contributions: [Check this complete list of contributors on GitHub](https:/
 
 Translations: [Check the project on POEditor to see language contributors](https://poeditor.com/projects/view?id=97843)
 
+See also contributors to [projects used by StreetComplete](https://github.com/westnordost/StreetComplete/blob/master/CONTRIBUTING.md#streetcomplete-related-projects), some were even specially created to help it.
+
 ## Licenses & Sources
 
 It's [GPL v3](https://www.gnu.org/licenses/gpl.html) for code and mixed Creative Common licenses for assets (of which none is more restrictive than [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/)) with two images used under fair use.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,6 +16,7 @@ Translations: [Check the project on POEditor to see language contributors](https
 It's [GPL v3](https://www.gnu.org/licenses/gpl.html) for code and mixed Creative Common licenses for assets (of which none is more restrictive than [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/)) with two images used under fair use.
 
 Check
+
 * [res/authors.txt](res/authors.txt) and
 * [app/src/main/res/authors.txt](app/src/main/res/authors.txt)
 * [app/src/main/assets/authors.txt](app/src/main/assets/authors.txt)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,9 +17,8 @@ See also contributors to [projects used by StreetComplete](https://github.com/we
 
 It's [GPL v3](https://www.gnu.org/licenses/gpl.html) for code and mixed Creative Common licenses for assets (of which none is more restrictive than [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/)). Additionally two images are used under fair use.
 
-Check
+Check following files to see sources and authors of the single resources in detail.
 
-* [res/authors.txt](res/authors.txt) and
+* [res/authors.txt](res/authors.txt)
 * [app/src/main/res/authors.txt](app/src/main/res/authors.txt)
 * [app/src/main/assets/authors.txt](app/src/main/assets/authors.txt)
-to see sources and authors of the single resources in detail. 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,7 +15,7 @@ See also contributors to [projects used by StreetComplete](https://github.com/we
 
 ## Licenses & Sources
 
-It's [GPL v3](https://www.gnu.org/licenses/gpl.html) for code and mixed Creative Common licenses for assets (of which none is more restrictive than [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/)) with two images used under fair use.
+It's [GPL v3](https://www.gnu.org/licenses/gpl.html) for code and mixed Creative Common licenses for assets (of which none is more restrictive than [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/)). Additionally two images are used under fair use.
 
 Check
 


### PR DESCRIPTION
- use more portable markdown formatting (AKA my markdown editor was failing)
- link to section in docs listing projects used by SC or created for SC
- simplify overly long sentence
- make list format less confusing