### PR TITLE
stop asking about bicycle parking type where there is no access

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_type/AddBikeParkingType.kt
@@ -7,7 +7,7 @@ import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao
 
 class AddBikeParkingType(o: OverpassMapDataDao) : SimpleOverpassQuestType<String>(o) {
 
-    override val tagFilters = "nodes, ways with amenity=bicycle_parking and access!=private and !bicycle_parking"
+    override val tagFilters = "nodes, ways with amenity=bicycle_parking and access !~ private|no and !bicycle_parking"
     override val commitMessage = "Add bicycle parking type"
     override val icon = R.drawable.ic_quest_bicycle_parking
 


### PR DESCRIPTION
access=private was handled already, acces=no not

during testing I discovered that this tagging is fairly rare but still happens (for example https://www.openstreetmap.org/way/354177980 used during testing)