### PR TITLE
Add deauthorize comfirmation dialog

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
@@ -55,7 +55,21 @@ class SettingsFragment : PreferenceFragmentCompat(),
         addPreferencesFromResource(R.xml.preferences)
 
 	    preferenceScreen.findPreference("oauth").setOnPreferenceClickListener {
-	        fragmentManager?.let { OsmOAuthDialogFragment().show(it, OsmOAuthDialogFragment.TAG) }
+            // If OSM account is authorized, ask if user want to deauthorize it
+            // If not, just do OAuth
+            context?.takeIf { oAuth.isAuthorized }?.let {
+                val username = prefs.getString(Prefs.OSM_USER_NAME, null)
+                val message = if (username != null) getString(R.string.oauth_confirm_deauthroize_username, username)
+                else getString(R.string.oauth_confirm_deauthroize)
+
+                AlertDialog.Builder(it)
+                        .setMessage(message)
+                        .setPositiveButton(R.string.oauth_deauthroize_confirmation) { _, _ ->
+                            oAuth.saveConsumer(null)
+                        }
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .show()
+            } ?: fragmentManager?.let { OsmOAuthDialogFragment().show(it, OsmOAuthDialogFragment.TAG) }
             true
         }
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2,6 +2,9 @@
 <resources>
     <string name="action_settings">"設定"</string>
     <string name="oauth_communication_error">"無法連接到驗證伺服器"</string>
+    <string name="oauth_confirm_deauthroize_username">"目前驗證的OSM帳號為：%s，你想撤消嗎？"</string>
+    <string name="oauth_confirm_deauthroize">"目前已連結OSM帳號，你想撤消嗎？"</string>
+    <string name="oauth_deauthroize_confirmation">"撤消"</string>
     <string name="loading">"載入中"</string>
     <string name="retry">"重試"</string>
     <string name="oauth_cancelled">"取消驗證"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,9 @@
 <resources>
     <string name="action_settings">"Settings"</string>
     <string name="oauth_communication_error">"Unable to reach the authorization server"</string>
+    <string name="oauth_confirm_deauthroize_username">"You are now linked with OSM account: %s, do you want to deauthorize it?"</string>
+    <string name="oauth_confirm_deauthroize">"You are now linked with an OSM account, do you want to deauthorize it?"</string>
+    <string name="oauth_deauthroize_confirmation">"deauthorize"</string>
     <string name="loading">"Loading"</string>
     <string name="retry">"Retry"</string>
     <string name="oauth_cancelled">"Authorization canceled"</string>


### PR DESCRIPTION
#1534

When user click on OAuth preference option and OSM account is authorized,
ask if user want to deauthorize it. If not, just do OAuth.

![Screenshot_20190825-203737](https://user-images.githubusercontent.com/19887090/63650023-4a6a6380-c778-11e9-8c6d-0af0414c90b2.jpg)
