### PR TITLE
exclude ruined buildings from quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -17,7 +17,7 @@ class AddBuildingLevels(o: OverpassMapDataDao) : SimpleOverpassQuestType<Buildin
             "commercial","office","warehouse","industrial","manufacture","parking","farm",
             "farm_auxiliary","barn","cabin").joinToString("|") + "\n" +
         " and !building:levels and !height and !building:height\n " +
-        " and !man_made and location!=underground\n "
+        " and !man_made and location!=underground and ruins!=yes\n "
     override val commitMessage = "Add building and roof levels"
     override val icon = R.drawable.ic_quest_building_levels
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingType.kt
@@ -11,7 +11,7 @@ class AddBuildingType (o: OverpassMapDataDao) : SimpleOverpassQuestType<String>(
     // information about the purpose of the building, so no need to force asking it
     override val tagFilters = """
         ways, relations with building = yes
-        and !man_made and !historic and !military and !power and location!=underground
+        and !man_made and !historic and !military and !power and location!=underground and ruins!=yes
     """
     override val commitMessage = "Add building types"
     override val icon = R.drawable.ic_quest_building

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/housenumber/AddHousenumber.kt
@@ -219,6 +219,6 @@ class AddHousenumber(private val overpass: OverpassMapDataDao) : OsmElementQuest
         private const val BUILDINGS_WITHOUT_ADDRESS_FILTER =
             "['building'~'^(house|residential|apartments|detached|terrace|dormitory|semi|semidetached_house|farm|" +
             "school|civic|college|university|public|hospital|kindergarten|train_station|hotel|" +
-            "retail|commercial)$'][location!=underground]" + NO_ADDRESS_FILTER
+            "retail|commercial)$'][location!=underground][ruins!=yes]" + NO_ADDRESS_FILTER
     }
 }


### PR DESCRIPTION
Such buildings are often not really answerable and value of answers will be low. Large number of questions will end in failure to reply.

Some ruins were built was reasons that are not clear now, a roof may be caved in making the roof shape question unanswerable (and not really fixable by tagging it), building levels are weird at the best (is 0 correct in case of completely missing roof) etc.

Though I admit that the real reason is that at least in some places many object could have historic=* tag (that is already filtering out objects in building type quest), but historic key is untagged. Many of such objects have ruins=yes.

fixes #1541