### PR TITLE
make debug layout not crashing for more quest types

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/settings/ShowQuestFormsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/ShowQuestFormsActivity.kt
@@ -80,7 +80,7 @@ class ShowQuestFormsActivity : AppCompatActivity(), OsmQuestAnswerListener {
         val lng = Double.fromBits(prefs.getLong(Prefs.MAP_LONGITUDE, 0.0.toBits()))
         val pos = OsmLatLon(lat, lng)
         val elementGeometry = ElementGeometry(pos)
-        val element = OsmNode(1, 1, pos, mapOf())
+        val element = OsmNode(1, 1, pos, mapOf("highway" to "cycleway", "building" to "residential"))
 
         val f = questType.createForm()
         val args = QuestAnswerComponent.createArguments(1, QuestGroup.OSM)


### PR DESCRIPTION
for example path quests and "no house number" answer of house number quest are working

note and oneway quests are still crashing, but are not trivially fixable by adding tags 