### PR TITLE
Reorder some crosswalk related quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -152,12 +152,12 @@ public class QuestModule
 				new AddToiletsFee(o), // used by OsmAnd in the object description
 				new AddBabyChangingTable(o), // used by OsmAnd in the object description
 				new AddBikeParkingCover(o), // used by OsmAnd in the object description
-				new AddTrafficSignalsSound(o),
+				new AddTactilePavingCrosswalk(o), // Paving can be completed while waiting to cross
+				new AddTrafficSignalsSound(o), // Sound needs to be done as or after you're crossing
 				new AddRoofShape(o),
 				new AddWheelchairAccessPublicTransport(o),
 				new AddWheelchairAccessOutside(o),
 				new AddTactilePavingBusStop(o),
-				new AddTactilePavingCrosswalk(o),
 				new AddBridgeStructure(o),
 				new AddReligionToWaysideShrine(o),
 				new AddCyclewaySegregation(o),


### PR DESCRIPTION
So they appear in a logical order when completing them.

I was tempted to move AddTrafficSignalsButton up too, above the others, but I appreciate it's less useful.