### PR TITLE
Disable 3D buildings when creating notes

### DIFF
--- a/app/src/main/assets/map_theme/layers/land.yaml
+++ b/app/src/main/assets/map_theme/layers/land.yaml
@@ -110,9 +110,6 @@ styles:
     buildings-style:
         base: polygons
         blend: opaque
-        shaders:
-            blocks:
-                position:
     buildings-outline-style:
         base: lines
         blend: inlay

--- a/app/src/main/assets/map_theme/layers/land.yaml
+++ b/app/src/main/assets/map_theme/layers/land.yaml
@@ -110,6 +110,9 @@ styles:
     buildings-style:
         base: polygons
         blend: opaque
+        shaders:
+            blocks:
+                position:
     buildings-outline-style:
         base: lines
         blend: inlay

--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
@@ -948,7 +948,7 @@ public class MainActivity extends AppCompatActivity implements
 	{
 		freezeMap();
 		showInBottomSheet(new CreateNoteFragment());
-		mapFragment.toggle3DBuildings(false);
+		mapFragment.setShow3DBuildings(false);
 	}
 
 	/* ---------------------------------- VisibleQuestListener ---------------------------------- */
@@ -998,7 +998,7 @@ public class MainActivity extends AppCompatActivity implements
 			((IsCloseableBottomSheet)f).onClickClose(() ->
 			{
 				getSupportFragmentManager().popBackStackImmediate(BOTTOM_SHEET, FragmentManager.POP_BACK_STACK_INCLUSIVE);
-				mapFragment.toggle3DBuildings(true);
+				mapFragment.setShow3DBuildings(true);
 				unfreezeMap();
 			});
 		}

--- a/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/MainActivity.java
@@ -948,6 +948,7 @@ public class MainActivity extends AppCompatActivity implements
 	{
 		freezeMap();
 		showInBottomSheet(new CreateNoteFragment());
+		mapFragment.toggle3DBuildings(false);
 	}
 
 	/* ---------------------------------- VisibleQuestListener ---------------------------------- */
@@ -997,6 +998,7 @@ public class MainActivity extends AppCompatActivity implements
 			((IsCloseableBottomSheet)f).onClickClose(() ->
 			{
 				getSupportFragmentManager().popBackStackImmediate(BOTTOM_SHEET, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+				mapFragment.toggle3DBuildings(true);
 				unfreezeMap();
 			});
 		}

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
@@ -36,9 +36,12 @@ import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.MapView;
 import com.mapzen.tangram.Marker;
 import com.mapzen.tangram.SceneError;
+import com.mapzen.tangram.SceneUpdate;
 import com.mapzen.tangram.TouchInput;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import de.westnordost.osmapi.map.data.LatLon;
 import de.westnordost.streetcomplete.Prefs;
@@ -705,6 +708,17 @@ public class MapFragment extends Fragment implements
 	{
 		if(mapControls != null) mapControls.hideControls();
 	}
+
+	public void toggle3DBuildings(boolean toggleOn)
+	{
+		onSceneUpdate();
+		
+		List<SceneUpdate> updates = new ArrayList<>();
+		updates.add(new SceneUpdate("layers.buildings.draw.buildings-style.extrude", toggleOn ? "true" : "false"));
+		updates.add(new SceneUpdate("layers.buildings.draw.buildings-outline-style.extrude", toggleOn ? "true" : "false"));
+		controller.updateSceneAsync(updates);
+	}
+
 	private void onSceneUpdate() {
 		locationMarker = null;
 		directionMarker = null;

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
@@ -714,9 +714,7 @@ public class MapFragment extends Fragment implements
 		onSceneUpdate();
 		
 		List<SceneUpdate> updates = new ArrayList<>();
-		updates.add(new SceneUpdate("scene.animated", toggleOn ? "false" : "true"));
-		updates.add(new SceneUpdate("styles.buildings-style.shaders.blocks.position",
-			toggleOn ? "" : "position.z = position.z / exp((u_time - 0.7) * step(0.7, u_time));"));
+		updates.add(new SceneUpdate("layers.buildings.draw.buildings-style.extrude", toggleOn ? "true" : "false"));
 		updates.add(new SceneUpdate("layers.buildings.draw.buildings-outline-style.extrude", toggleOn ? "true" : "false"));
 		controller.updateSceneAsync(updates);
 	}

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
@@ -625,7 +625,9 @@ public class MapFragment extends Fragment implements
 		compass.onDestroy();
 		if(mapView != null) mapView.onDestroy();
 		controller = null;
-		onSceneUpdate();
+		locationMarker = null;
+		directionMarker = null;
+		accuracyMarker = null;
 	}
 
 	@Override public void onLowMemory()
@@ -709,19 +711,23 @@ public class MapFragment extends Fragment implements
 		if(mapControls != null) mapControls.hideControls();
 	}
 
-	public void toggle3DBuildings(boolean toggleOn)
+	public void setShow3DBuildings(boolean toggleOn)
 	{
-		onSceneUpdate();
-		
 		List<SceneUpdate> updates = new ArrayList<>();
 		updates.add(new SceneUpdate("layers.buildings.draw.buildings-style.extrude", toggleOn ? "true" : "false"));
 		updates.add(new SceneUpdate("layers.buildings.draw.buildings-outline-style.extrude", toggleOn ? "true" : "false"));
-		controller.updateSceneAsync(updates);
+		updateSceneAsync(updates);
 	}
 
-	private void onSceneUpdate() {
+	/**
+	 * Call this method instead of MapController.updateSceneAsync() when doing Scene update.
+	 * Just to prevent app crash with invalidated markers.
+	 */
+	protected int updateSceneAsync(List<SceneUpdate> sceneUpdates)
+	{
 		locationMarker = null;
 		directionMarker = null;
 		accuracyMarker = null;
+		return controller.updateSceneAsync(sceneUpdates);
 	}
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
@@ -714,7 +714,9 @@ public class MapFragment extends Fragment implements
 		onSceneUpdate();
 		
 		List<SceneUpdate> updates = new ArrayList<>();
-		updates.add(new SceneUpdate("layers.buildings.draw.buildings-style.extrude", toggleOn ? "true" : "false"));
+		updates.add(new SceneUpdate("scene.animated", toggleOn ? "false" : "true"));
+		updates.add(new SceneUpdate("styles.buildings-style.shaders.blocks.position",
+			toggleOn ? "" : "position.z = position.z / exp((u_time - 0.7) * step(0.7, u_time));"));
 		updates.add(new SceneUpdate("layers.buildings.draw.buildings-outline-style.extrude", toggleOn ? "true" : "false"));
 		controller.updateSceneAsync(updates);
 	}

--- a/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/tangram/MapFragment.java
@@ -622,9 +622,7 @@ public class MapFragment extends Fragment implements
 		compass.onDestroy();
 		if(mapView != null) mapView.onDestroy();
 		controller = null;
-		directionMarker = null;
-		accuracyMarker = null;
-		locationMarker = null;
+		onSceneUpdate();
 	}
 
 	@Override public void onLowMemory()
@@ -706,5 +704,10 @@ public class MapFragment extends Fragment implements
 	public void hideMapControls()
 	{
 		if(mapControls != null) mapControls.hideControls();
+	}
+	private void onSceneUpdate() {
+		locationMarker = null;
+		directionMarker = null;
+		accuracyMarker = null;
 	}
 }


### PR DESCRIPTION
To solve #1589, this PR use [`MapController.updateSceneAsync()`](https://tangrams.readthedocs.io/en/latest/API-Reference/android-sdk/0.10.0/com/mapzen/tangram/MapController.html#updateSceneAsync-java.util.List-) to disable 3D buildings at runtime, includes the following changes in order:

1. 2ec0366
Add method `onSceneUpdate()` to clean added Markers before doing scene update, or APP just crash.
This is another issue explained in #1606.

1. 342af32
Add method `toggle3DBuildings(boolean)` into `MapFragment`. So it could be used to disable/enable 3D building draws when `CreateNoteFragment` is in/out. Because the use case in #1589 is to make sure where to put a new note, so buildings draws should not be invisible, but turn off extrude to show its shape.
![output2](https://user-images.githubusercontent.com/19887090/67104174-0d12d700-f1f9-11e9-8dad-537df216e62f.gif)

1. 81bb301
Add animation when toggling buildings draws. Because [transition](https://tangrams.readthedocs.io/en/latest/Syntax-Reference/draw/#transition) cannot be applied to polygon. To make animation, the way is to update `shaders` value to shrink building height. Also 3 lines were added into scene file, so map-style repo need to be updated.
![output](https://user-images.githubusercontent.com/19887090/67104182-10a65e00-f1f9-11e9-8362-6f598a02eb6a.gif)

---
- Be aware these code changes redraw the map when clicking create-note button, this may affects user experience
- I am not sure use animation and change scene file is a good idea. So if making 3D buildings disabled is good enough, just merge 342af32
- If animation needs enhancement, take a look at tangram doc about [shaders](https://tangrams.readthedocs.io/en/latest/Syntax-Reference/shaders/) and [WebGL API](https://www.khronos.org/files/webgl/webgl-reference-card-1_0.pdf)