### PR TITLE
Add handrail quest: ask if steps have a handrail or not

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.java
@@ -23,6 +23,7 @@ import de.westnordost.streetcomplete.quests.building_type.AddBuildingType;
 import de.westnordost.streetcomplete.quests.building_underground.AddIsBuildingUnderground;
 import de.westnordost.streetcomplete.quests.foot.AddProhibitedForPedestrians;
 import de.westnordost.streetcomplete.quests.general_fee.AddGeneralFee;
+import de.westnordost.streetcomplete.quests.handrail.AddHandrail;
 import de.westnordost.streetcomplete.quests.leaf_detail.AddForestLeafType;
 import de.westnordost.streetcomplete.quests.localized_name.AddBusStopName;
 import de.westnordost.streetcomplete.quests.bus_stop_shelter.AddBusStopShelter;
@@ -166,6 +167,7 @@ public class QuestModule
 				new MarkCompletedBuildingConstruction(o),
 				new AddGeneralFee(o),
 				new AddSelfServiceLaundry(o),
+				new AddHandrail(o), // for accessibility of pedestrian routing
 
 				// ↓ 8. defined in the wiki, but not really used by anyone yet. Just collected for
 				//      the sake of mapping it in case it makes sense later

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -1,0 +1,48 @@
+package de.westnordost.streetcomplete.quests.handrail
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.SimpleOverpassQuestType
+import de.westnordost.streetcomplete.data.osm.changes.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.download.OverpassMapDataDao
+import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
+
+/**
+ * Only ask about whether there exists a handrail, not about the location (left, right and/or
+ * middle), because the primary use case here is accessibility of the path (not 3d rendering, etc),
+ * which does not depend on the location of the handrail.
+ * The details would only slow down the answering in a survey by requiring more thought and a more
+ * complex GUI (interpreting the direction of the OSM way for example).
+ *
+ * Github Issue for this quest:
+ * https://github.com/westnordost/StreetComplete/issues/1390
+ */
+class AddHandrail(overpassServer: OverpassMapDataDao) : SimpleOverpassQuestType<Boolean>(overpassServer) {
+    // Do not include nodes and relations, even though these exist with the right tags, because
+    // according to the wiki page for `highway=steps` [2] it can only be applied to ways. It also
+    // does not make much sense for other types of elements and it is more likely to be a
+    // Do not exclude elements tagged with `handrail:left`, `handrail:center` or `handrail:right`
+    // because according to the wiki page for `handrail=*` [1], the `handrail` tag should
+    // always have just `yes` or
+    // `no` as a value to indicate the existence of a handrail somewhere. If there is a mismatch of
+    // the tags afterwards, that can be recognized using one of the various
+    // Quality Assurance tools [3].
+    // [1] https://wiki.openstreetmap.org/wiki/Key:handrail
+    // [2] https://wiki.openstreetmap.org/wiki/Tag:highway%3Dsteps
+    // [3] https://wiki.openstreetmap.org/wiki/Quality_assurance
+    override val tagFilters = "nodes with highway = steps and !handrail"
+
+    // changeset comment to be used for uploading changes made through this quest
+    override val commitMessage = "Add whether steps have a handrail"
+
+    // icon for displaying quest on the map
+    override val icon = R.drawable.ic_quest_handrail
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_handrail_title
+
+    // use simple yes/no user interface without additional pictures for prompting user for answer
+    override fun createForm() = YesNoQuestAnswerFragment()
+
+    override fun applyAnswerTo(answerHandrailExists: Boolean, changes: StringMapChangesBuilder) {
+        changes.add("handrail", if (answerHandrailExists) "yes" else "no")
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -19,7 +19,8 @@ import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
 class AddHandrail(overpassServer: OverpassMapDataDao) : SimpleOverpassQuestType<Boolean>(overpassServer) {
     // Do not include nodes and relations, even though these exist with the right tags, because
     // according to the wiki page for `highway=steps` [2] it can only be applied to ways. It also
-    // does not make much sense for other types of elements and it is more likely to be a
+    // does not make much sense for other types of elements and it is more likely to be a tagging
+    // mistake.
     // Do not exclude elements tagged with `handrail:left`, `handrail:center` or `handrail:right`
     // because according to the wiki page for `handrail=*` [1], the `handrail` tag should
     // always have just `yes` or

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -12,9 +12,6 @@ import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
  * which does not depend on the location of the handrail.
  * The details would only slow down the answering in a survey by requiring more thought and a more
  * complex GUI (interpreting the direction of the OSM way for example).
- *
- * Github Issue for this quest:
- * https://github.com/westnordost/StreetComplete/issues/1390
  */
 class AddHandrail(overpassServer: OverpassMapDataDao) : SimpleOverpassQuestType<Boolean>(overpassServer) {
     // Do not include nodes and relations, even though these exist with the right tags, because

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/handrail/AddHandrail.kt
@@ -18,24 +18,24 @@ import de.westnordost.streetcomplete.quests.YesNoQuestAnswerFragment
  */
 class AddHandrail(overpassServer: OverpassMapDataDao) : SimpleOverpassQuestType<Boolean>(overpassServer) {
     // Do not include nodes and relations, even though these exist with the right tags, because
-    // according to the wiki page for `highway=steps` [2] it can only be applied to ways. It also
+    // according to the wiki page for `highway=steps` [1] it can only be applied to ways. It also
     // does not make much sense for other types of elements and it is more likely to be a tagging
     // mistake.
-    // Do not exclude elements tagged with `handrail:left`, `handrail:center` or `handrail:right`
-    // because according to the wiki page for `handrail=*` [1], the `handrail` tag should
-    // always have just `yes` or
-    // `no` as a value to indicate the existence of a handrail somewhere. If there is a mismatch of
-    // the tags afterwards, that can be recognized using one of the various
-    // Quality Assurance tools [3].
-    // [1] https://wiki.openstreetmap.org/wiki/Key:handrail
-    // [2] https://wiki.openstreetmap.org/wiki/Tag:highway%3Dsteps
+    // Exclude elements tagged with `handrail:left`, `handrail:center` or `handrail:right`
+    // even though according to the wiki page for `handrail=*` [1], the `handrail` tag should
+    // always have just `yes` or `no` as a value to indicate the existence of a handrail somewhere.
+    // If one of these tags is present but without a `handrail` tag, we still assume the survey data
+    // itself was valid, so we do not need to use survey time to add the implied `handrail` tag.
+    // If there is such a case, mappers can fix this from remote locations, maybe with the help of
+    // one of the various Quality Assurance tools [3].
+    // [1] https://wiki.openstreetmap.org/wiki/Tag:highway%3Dsteps
+    // [2] https://wiki.openstreetmap.org/wiki/Key:handrail
     // [3] https://wiki.openstreetmap.org/wiki/Quality_assurance
-    override val tagFilters = "nodes with highway = steps and !handrail"
+    override val tagFilters = """ways with highway = steps
+        and !handrail and !handrail:left and !handrail:center and !handrail:right"""
 
-    // changeset comment to be used for uploading changes made through this quest
     override val commitMessage = "Add whether steps have a handrail"
 
-    // icon for displaying quest on the map
     override val icon = R.drawable.ic_quest_handrail
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_handrail_title
@@ -43,7 +43,7 @@ class AddHandrail(overpassServer: OverpassMapDataDao) : SimpleOverpassQuestType<
     // use simple yes/no user interface without additional pictures for prompting user for answer
     override fun createForm() = YesNoQuestAnswerFragment()
 
-    override fun applyAnswerTo(answerHandrailExists: Boolean, changes: StringMapChangesBuilder) {
-        changes.add("handrail", if (answerHandrailExists) "yes" else "no")
+    override fun applyAnswerTo(answer: Boolean, changes: StringMapChangesBuilder) {
+        changes.add("handrail", if (answer) "yes" else "no")
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -683,5 +683,5 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="confirmation_authorize_now_note">You can do this later on the settings screen.</string>
     <string name="quest_generalFee_title">Does it cost a fee to enter %s?</string>
     <string name="quest_laundrySelfService_title">Is this laundry a self service laundry?</string>
-
+    <string name="quest_handrail_title">Do these steps have a handrail?</string>
 </resources>


### PR DESCRIPTION
Please review my decision and explanation for only including `node`s and excluding only the `handrail` tag.
I tried to add a bit of documentation in the code for others to understand the rationale of how this quest is implemented (what is included/excluded etc), I hope it is done okay.

I wasn't sure about the ordering of the quest in relation to the others, maybe you have some ideas for that.

fixes #1390