### PR TITLE
Add landuse to name Quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -54,9 +54,10 @@ class AddPlaceName(
                 "amusement_arcade", "adult_gaming_centre", "tanning_salon", "horse_riding"
             ),
             "landuse" to arrayOf(
-                    "cemetery",
-                    "allotments", "recreation_ground",
-                    "military", "quarry"
+                    "cemetery", "allotments"
+            ),
+            "military" to arrayOf(
+                "airfield", "barracks", "training_area"
             )
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n  or ") + "\n" + """
         )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -52,6 +52,11 @@ class AddPlaceName(
                 "nature_reserve", "sports_centre", "fitness_centre", "dance", "golf_course",
                 "water_park", "miniature_golf", "stadium", "marina", "bowling_alley",
                 "amusement_arcade", "adult_gaming_centre", "tanning_salon", "horse_riding"
+            ),
+            "landuse" to arrayOf(
+                    "cemetery",
+                    "allotments", "recreation_ground",
+                    "military", "quarry"
             )
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n  or ") + "\n" + """
         )


### PR DESCRIPTION
This pullreqest adds landuse to the name quest.

i've selected "cemetery", "allotments", "recreation_ground",  "military", "quarry" for this quest.

i think these are the few landuses which always have an name.

open to feedback and revision request