### PR TITLE
Make master list and sync them across the quests

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -19,11 +19,17 @@ class AddOpeningHours (o: OverpassMapDataDao) : SimpleOverpassQuestType<OpeningH
          or amenity = recycling and recycling_type = centre
          or tourism = information and information = office
          or """.trimIndent() +
+
+        // The common list is shared by the name quest, the opening hours quest and the wheelchair quest.
+        // So when adding other tags to the common list keep in mind that they need to be appropriate for all those quests.
+        // Independent tags can by added in the "opening_hours only" tab.
+
         mapOf(
             "amenity" to arrayOf(
+                // common
                 "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
-                "cinema", "planetarium", "casino", "library",                                                          // amenities
-                "townhall", "courthouse", "embassy", "community_centre", "youth_centre",                               // civic
+                "cinema", "planetarium", "casino", "arts_centre",                                                      // amenities
+                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
                 // not ATM because too often it's simply 24/7 and too often it is confused with
                 // a bank that might be just next door because the app does not tell the user what
                 // kind of object this is about
@@ -32,22 +38,25 @@ class AddOpeningHours (o: OverpassMapDataDao) : SimpleOverpassQuestType<OpeningH
                 "dentist", "doctors", "clinic", "pharmacy", "veterinary"                                               // health
             ),
             "tourism" to arrayOf(
+                // common
                 "zoo", "aquarium", "theme_park", "gallery", "museum"
                 // and tourism=information, see above
             ),
             "leisure" to arrayOf(
                 // not sports_centre because these are often sports clubs which have no walk-in
                 // opening hours but training times
+
+                // common
                 "fitness_centre", "dance", "golf_course", "water_park",
                 "miniature_golf", "bowling_alley", "horse_riding",  "amusement_arcade",
                 "adult_gaming_centre", "tanning_salon"
             ),
             "office" to arrayOf(
-                // also listed for AddWheelchair quest
+                // common
                 "insurance", "government", "travel_agent", "tax_advisor", "religion", "employment_agency"
             ),
             "craft" to arrayOf(
-                // also listed for AddWheelchair quest
+                // common
                 "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
                 "electronics_repair", "key_cutter", "stonemason"
             )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -28,7 +28,7 @@ class AddOpeningHours (o: OverpassMapDataDao) : SimpleOverpassQuestType<OpeningH
             "amenity" to arrayOf(
                 // common
                 "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
-                "cinema", "planetarium", "casino", "arts_centre",                                                      // amenities
+                "cinema", "planetarium", "casino",                                                                     // amenities
                 "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
                 // not ATM because too often it's simply 24/7 and too often it is confused with
                 // a bank that might be just next door because the app does not tell the user what

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -73,21 +73,6 @@ class AddPlaceName(
                 //name only
                 "nature_reserve", "sports_centre", "dance", "golf_course",
                 "stadium", "marina"
-            ),
-            "office" to arrayOf(
-                // common
-                "insurance", "government", "travel_agent", "tax_advisor", "religion", "employment_agency",
-
-                // name and wheelchair
-                "lawyer", "estate_agent", "political_party", "therapist"
-            ),
-            "craft" to arrayOf(
-                // common
-                "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
-                "electronics_repair", "key_cutter", "stonemason",
-
-                // name and wheelchair
-                "winery"
             )
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n  or ") + "\n" + """
         )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -27,31 +27,67 @@ class AddPlaceName(
           or office
           or tourism = information and information = office 
           or """.trimIndent() +
+
+        // The common list is shared by the name quest, the opening hours quest and the wheelchair quest.
+        // So when adding other tags to the common list keep in mind that they need to be appropriate for all those quests.
+        // Independent tags can by added in the "name only" tab.
+
         mapOf(
             "amenity" to arrayOf(
-                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub",                  // eat & drink
-                "cinema", "theatre", "planetarium", "arts_centre", "studio",                                                            // culture
-                "events_venue", "conference_centre", "exhibition_centre", "music_venue",                                                // events
-                "townhall", "prison", "courthouse", "embassy", "police", "fire_station", "ranger_station",                              // civic
-                "bank", "bureau_de_change", "money_transfer", "post_office", "library", "marketplace", "internet_cafe",                 // commercial
-                "community_centre", "social_facility", "nursing_home", "childcare", "retirement_home", "social_centre", "youth_centre", // social
-                "car_wash", "car_rental", "boat_rental", "fuel", "ferry_terminal",                                                      // transport
-                "dentist", "doctors", "clinic", "pharmacy", "hospital",                                                                 // health care
-                "place_of_worship", "monastery",                                                                                        // religious
-                "kindergarten", "school", "college", "university", "research_institute",                                                // education
-                "driving_school", "dive_centre", "language_school", "music_school",                                                     // learning
-                "casino", "brothel", "gambling", "love_hotel", "stripclub",                                                             // bad stuff
-                "animal_boarding", "animal_shelter", "animal_breeding", "veterinary"                                                    // animals
+                // common
+                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
+                "cinema", "planetarium", "casino", "arts_centre",                                                      // amenities
+                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
+                "bank", /*atm,*/ "bureau_de_change", "money_transfer", "post_office", "marketplace", "internet_cafe",  // commercial
+                "car_wash", "car_rental", "boat_rental", "fuel",                                                       // car stuff
+                "dentist", "doctors", "clinic", "pharmacy", "veterinary",                                              // health
+
+                //name only
+                "theatre", "studio",                                                               // culture
+                "events_venue", "conference_centre", "exhibition_centre", "music_venue",            // events
+                "prison", "police", "fire_station", "ranger_station",                               // civic
+                "social_facility", "nursing_home", "childcare", "retirement_home", "social_centre", // social
+                "ferry_terminal",                                                                   // transport
+                "hospital",                                                                         // health care
+                "place_of_worship", "monastery",                                                    // religious
+                "kindergarten", "school", "college", "university", "research_institute",            // education
+                "driving_school", "dive_centre", "language_school", "music_school",                 // learning
+                "brothel", "gambling", "love_hotel", "stripclub",                                   // bad stuff
+                "animal_boarding", "animal_shelter", "animal_breeding"                              // animals
             ),
             "tourism" to arrayOf(
-                "attraction", "zoo", "aquarium", "theme_park", "gallery", "museum",                                                     // attractions
+                // common
+                "zoo", "aquarium", "theme_park", "gallery", "museum",
+
+                // name only
+                "attraction",                                                                                                           // attractions
                 "hotel", "guest_house", "motel", "hostel", "alpine_hut", "apartment", "resort", "camp_site", "caravan_site", "chalet"   // accommodations
                 // and tourism=information, see above
             ),
             "leisure" to arrayOf(
-                "nature_reserve", "sports_centre", "fitness_centre", "dance", "golf_course",
-                "water_park", "miniature_golf", "stadium", "marina", "bowling_alley",
-                "amusement_arcade", "adult_gaming_centre", "tanning_salon", "horse_riding"
+                //common
+                "fitness_centre", "dance", "golf_course", "water_park",
+                "miniature_golf", "bowling_alley", "horse_riding",  "amusement_arcade",
+                "adult_gaming_centre", "tanning_salon",
+
+                //name only
+                "nature_reserve", "sports_centre", "dance", "golf_course",
+                "stadium", "marina"
+            ),
+            "office" to arrayOf(
+                // common
+                "insurance", "government", "travel_agent", "tax_advisor", "religion", "employment_agency",
+
+                // name and wheelchair
+                "lawyer", "estate_agent", "political_party", "therapist"
+            ),
+            "craft" to arrayOf(
+                // common
+                "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
+                "electronics_repair", "key_cutter", "stonemason",
+
+                // name and wheelchair
+                "winery"
             )
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n  or ") + "\n" + """
         )

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -36,14 +36,14 @@ class AddPlaceName(
             "amenity" to arrayOf(
                 // common
                 "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
-                "cinema", "planetarium", "casino", "arts_centre",                                                      // amenities
+                "cinema", "planetarium", "casino",                                                                     // amenities
                 "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
                 "bank", /*atm,*/ "bureau_de_change", "money_transfer", "post_office", "marketplace", "internet_cafe",  // commercial
                 "car_wash", "car_rental", "boat_rental", "fuel",                                                       // car stuff
                 "dentist", "doctors", "clinic", "pharmacy", "veterinary",                                              // health
 
                 //name only
-                "theatre", "studio",                                                               // culture
+                "theatre", "studio", "arts_centre",                                                 // culture
                 "events_venue", "conference_centre", "exhibition_centre", "music_venue",            // events
                 "prison", "police", "fire_station", "ranger_station",                               // civic
                 "social_facility", "nursing_home", "childcare", "retirement_home", "social_centre", // social

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -32,7 +32,7 @@ class AddWheelchairAccessBusiness(o: OverpassMapDataDao) : SimpleOverpassQuestTy
                 "dentist", "doctors", "clinic", "pharmacy", "veterinary",                                              // health
 
                 // wheelchair only
-                "theatre", "arts_centre", "conference_centre",
+                "theatre", "conference_centre",
                 "police", "ranger_station","prison",
                 "kindergarten", "school", "college", "university", "research_institute",                                                // education
                 "driving_school", "dive_centre", "language_school", "music_school",                                                     // learning
@@ -45,7 +45,7 @@ class AddWheelchairAccessBusiness(o: OverpassMapDataDao) : SimpleOverpassQuestTy
                 "zoo", "aquarium", "theme_park", "gallery", "museum",
                 // wheelchair only
                 "attraction", "viewpoint",
-                "museum", "hotel", "guest_house", "hostel", "motel", "apartment", "chalet"
+                "hotel", "guest_house", "hostel", "motel", "apartment", "chalet"
             ),
             "leisure" to arrayOf(
                 // common

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -16,36 +16,58 @@ class AddWheelchairAccessBusiness(o: OverpassMapDataDao) : SimpleOverpassQuestTy
          or amenity = recycling and recycling_type = centre
          or tourism = information and information = office
          or """.trimIndent() +
+
+        // The common list is shared by the name quest, the opening hours quest and the wheelchair quest.
+        // So when adding other tags to the common list keep in mind that they need to be appropriate for all those quests.
+        // Independent tags can by added in the "wheelchair only" tab.
+
         mapOf(
             "amenity" to arrayOf(
-                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub",
-                "cinema", "library", "theatre", "arts_centre", "casino", "conference_centre",
-                "bank", "bureau_de_change", "money_transfer", "post_office", "internet_cafe", "marketplace",
-                "police", "ranger_station", "courthouse", "embassy", "townhall", "community_centre", "youth_centre",
-                "car_wash", "car_rental", "fuel", "driving_school",
-                "doctors", "clinic", "pharmacy", "veterinary", "dentist",
-                "place_of_worship"
+                // common
+                "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
+                "cinema", "planetarium", "casino", "arts_centre",                                                      // amenities
+                "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
+                "bank", /*atm,*/ "bureau_de_change", "money_transfer", "post_office", "marketplace", "internet_cafe",  // commercial
+                "car_wash", "car_rental", "boat_rental", "fuel",                                                       // car stuff
+                "dentist", "doctors", "clinic", "pharmacy", "veterinary",                                              // health
+
+                // wheelchair only
+                "theatre", "arts_centre", "conference_centre",
+                "police", "ranger_station","prison",
+                "kindergarten", "school", "college", "university", "research_institute",                                                // education
+                "driving_school", "dive_centre", "language_school", "music_school",                                                     // learning
+                "ferry_terminal",
+                "place_of_worship",
+                "hospital"
             ),
             "tourism" to arrayOf(
-                "zoo", "aquarium", "theme_park", "gallery", "attraction", "viewpoint",
+                // common
+                "zoo", "aquarium", "theme_park", "gallery", "museum",
+                // wheelchair only
+                "attraction", "viewpoint",
                 "museum", "hotel", "guest_house", "hostel", "motel", "apartment", "chalet"
             ),
             "leisure" to arrayOf(
-                "golf_course", "water_park", "miniature_golf", "dance",
-                "bowling_alley", "horse_riding", "sports_centre", "fitness_centre",
-                "amusement_arcade", "adult_gaming_centre", "tanning_salon"
+                // common
+                "fitness_centre", "dance", "golf_course", "water_park",
+                "miniature_golf", "bowling_alley", "horse_riding",  "amusement_arcade",
+                "adult_gaming_centre", "tanning_salon",
+                // wheelchair only
+                "sports_centre"
             ),
             "office" to arrayOf(
-                // also listed for AddOpeningHours quest
+                // common
                 "insurance", "government", "travel_agent", "tax_advisor", "religion", "employment_agency",
-                // not listed manually for other quests
+
+                // name and wheelchair
                 "lawyer", "estate_agent", "political_party", "therapist"
             ),
             "craft" to arrayOf(
-                // also listed for AddOpeningHours quest
+                // common
                 "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
                 "electronics_repair", "key_cutter", "stonemason",
-                // not listed manually for other quests
+
+                // name and wheelchair
                 "winery"
             )
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n or ") +

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusiness.kt
@@ -25,17 +25,17 @@ class AddWheelchairAccessBusiness(o: OverpassMapDataDao) : SimpleOverpassQuestTy
             "amenity" to arrayOf(
                 // common
                 "restaurant", "cafe", "ice_cream", "fast_food", "bar", "pub", "biergarten", "food_court", "nightclub", // eat & drink
-                "cinema", "planetarium", "casino", "arts_centre",                                                      // amenities
+                "cinema", "planetarium", "casino",                                                                     // amenities
                 "townhall", "courthouse", "embassy", "community_centre", "youth_centre", "library",                    // civic
                 "bank", /*atm,*/ "bureau_de_change", "money_transfer", "post_office", "marketplace", "internet_cafe",  // commercial
                 "car_wash", "car_rental", "boat_rental", "fuel",                                                       // car stuff
                 "dentist", "doctors", "clinic", "pharmacy", "veterinary",                                              // health
 
                 // wheelchair only
-                "theatre", "conference_centre",
+                "theatre", "conference_centre", "arts_centre",
                 "police", "ranger_station","prison",
-                "kindergarten", "school", "college", "university", "research_institute",                                                // education
-                "driving_school", "dive_centre", "language_school", "music_school",                                                     // learning
+                "kindergarten", "school", "college", "university", "research_institute",                               // education
+                "driving_school", "dive_centre", "language_school", "music_school",                                    // learning
                 "ferry_terminal",
                 "place_of_worship",
                 "hospital"


### PR DESCRIPTION
This PR makes master list for the name, opening hour and wheelchair quest.
all the unique tags stay separate in the quest and the list can be shared across quest.

I also shuffled some only present in some quest to the common list if it was appropriate for all three quest.

This PR also adds the office and craft tags to the name quest