### PR TITLE
Ensure we're checking if the speed value is unusual

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeedForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeedForm.kt
@@ -109,7 +109,7 @@ class AddMaxSpeedForm : AbstractQuestFormAnswerFragment<MaxSpeedAnswer>() {
 
     private fun userSelectedUnusualSpeed(): Boolean {
         val kmh = getSpeedFromInput()?.toKmh() ?: return false
-        return kmh > 140 || kmh > 20 && kmh % 5 != 0
+        return kmh > 140 || kmh > 20 && getSpeedFromInput()?.toValue() % 5 != 0
     }
 
     private fun switchToAdvisorySpeedLimit() {


### PR DESCRIPTION
Not the converted value in kmh, otherwise every mph value will be odd.

As I stuck in a comment in here:
https://github.com/westnordost/StreetComplete/pull/1622/files#r344422067
> This throws an "implausible" warning for 20 mph in the UK, and would do the same for 30. The % 5 bit needs to be done on the raw speed value rather than the converted kmh value.
> 
> I'm not quite sure how I didn't hit this before, or is this only triggered in some cases (this was a zone not a sign).

This code is entirely untested, but seemed trivial enough it was worth just opening a PR rather than an issue.