### PR TITLE
make situation with jars and weird glass types clear

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlassForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/recycling_glass/DetermineRecyclingGlassForm.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.quests.recycling_glass.RecyclingGlass.*
 
 
 class DetermineRecyclingGlassForm : AbstractQuestAnswerFragment<RecyclingGlass>() {
+    override val contentLayoutResId = R.layout.quest_determine_recycling_glass_explanation
 
     override val buttonsResId = R.layout.quest_buttonpanel_glass_glassbottles
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusinessForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusinessForm.kt
@@ -3,5 +3,5 @@ package de.westnordost.streetcomplete.quests.wheelchair_access
 import de.westnordost.streetcomplete.R
 
 class AddWheelchairAccessBusinessForm : WheelchairAccessAnswerForm() {
-    override val contentLayoutResId = R.layout.quest_wheelchair_business_explanation
+    override val contentLayoutResId = R.layout.quest_determine_recycling_glass_explanation
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusinessForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessBusinessForm.kt
@@ -3,5 +3,5 @@ package de.westnordost.streetcomplete.quests.wheelchair_access
 import de.westnordost.streetcomplete.R
 
 class AddWheelchairAccessBusinessForm : WheelchairAccessAnswerForm() {
-    override val contentLayoutResId = R.layout.quest_determine_recycling_glass_explanation
+    override val contentLayoutResId = R.layout.quest_wheelchair_business_explanation
 }

--- a/app/src/main/res/layout/quest_buttonpanel_glass_glassbottles.xml
+++ b/app/src/main/res/layout/quest_buttonpanel_glass_glassbottles.xml
@@ -15,6 +15,6 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         style="@style/BottomSheetButtonBarItem"
-        android:text="@string/quest_recycling_type_glass_bottles" />
+        android:text="@string/quest_recycling_type_glass_bottles_short" />
 
 </merge>

--- a/app/src/main/res/layout/quest_determine_recycling_glass_explanation.xml
+++ b/app/src/main/res/layout/quest_determine_recycling_glass_explanation.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/descriptionLabel"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/quest_determineRecyclingGlass_description_any_glass"
+    android:labelFor="@+id/nameInput"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,6 +706,6 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_recycling_type_scrap_metal">Scrap metal</string>
     <string name="quest_recycling_type_any_glass">Any glass</string>
     <string name="quest_recycling_glass_title">Can only glass bottles and jars be recycled here, or any type of glass?</string>
-    <string name="quest_determineRecyclingGlass_description_any_glass">Examples of glass that is often not accepted is such glass as from window panes, glassware, light bulbs or mirrors.</string>
+    <string name="quest_determineRecyclingGlass_description_any_glass">Examples of glass that is often not accepted: tempered glass, window panes, glassware, light bulbs or mirrors.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,6 +706,6 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_recycling_type_scrap_metal">Scrap metal</string>
     <string name="quest_recycling_type_any_glass">Any glass</string>
     <string name="quest_recycling_glass_title">Can only glass bottles and jars be recycled here, or any type of glass?</string>
-    <string name="quest_determineRecyclingGlass_description_any_glass">\"any glass\" includes window glass, glassware, tempered glass, optical glass, light bulb glass, mirrors and other that are often not accepted.</string>
+    <string name="quest_determineRecyclingGlass_description_any_glass">Examples of glass that is often not accepted is such glass as from window panes, glassware, light bulbs or mirrors.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -694,7 +694,8 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_recycling_type_cans">Cans</string>
     <string name="quest_recycling_type_clothes">Clothes</string>
     <string name="quest_recycling_type_green_waste">Garden waste</string>
-    <string name="quest_recycling_type_glass_bottles">Glass bottles</string>
+    <string name="quest_recycling_type_glass_bottles">Glass bottles and jars</string>
+    <string name="quest_recycling_type_glass_bottles_short">Bottles and jars</string>
     <string name="quest_recycling_type_paper">Paper</string>
     <string name="quest_recycling_type_plastic_generic">Plastic</string>
     <string name="quest_recycling_type_plastic">Any plastic</string>
@@ -704,6 +705,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_recycling_type_plastic_packaging">Plastic packaging only</string>
     <string name="quest_recycling_type_scrap_metal">Scrap metal</string>
     <string name="quest_recycling_type_any_glass">Any glass</string>
-    <string name="quest_recycling_glass_title">Can only glass bottles be recycled here, or any type of glass?</string>
+    <string name="quest_recycling_glass_title">Can only glass bottles and jars be recycled here, or any type of glass?</string>
+    <string name="quest_determineRecyclingGlass_description_any_glass">\"any glass\" includes window glass, glassware, tempered glass, optical glass, light bulb glass, mirrors and other that are often not accepted.</string>
 
 </resources>


### PR DESCRIPTION
this PR is made onto #1627 branch

in `recycling:glass` quest:
adds bonus info about weird glass types, replaces "glass bottles" by "bottles and jars" (glass should be made clear by context)

in `recycling:*` quest:
explicitly mentions jars (only glass bottles were mentioned in text, jars were on icon but excluded by text)

-----

My work on this pull request was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)