### PR TITLE
fix font licence

### DIFF
--- a/app/src/main/assets/authors.txt
+++ b/app/src/main/assets/authors.txt
@@ -3,6 +3,6 @@ File                  License / Source (if not given, follow link for license in
 
 boundaries.ser        ODbL 1.0            from https://josm.openstreetmap.de/browser/josm/trunk/data/boundaries.osm
                                           which is traced from the OpenStreetMap
-map_theme/fonts/*.*   Apache License 2.0  from https://github.com/ENT8R/streetcomplete-mapstyle/tree/master/fonts
+map_theme/fonts/*.*   SIL  OFL-1.1        from https://github.com/ENT8R/streetcomplete-mapstyle/tree/master/fonts (The Montserrat Project Authors)
 map_theme/*.*         GPL 3.0             from https://github.com/ENT8R/streetcomplete-mapstyle/
 osmfeatures/*.json    ISC license         from https://github.com/openstreetmap/iD/tree/master/dist/locales


### PR DESCRIPTION
see https://github.com/ENT8R/streetcomplete-mapstyle/issues/74
problems seems to be caused by cinnabar-style and was copied into ENT8R/streetcomplete-mapstyle and later here

-----

My work on this pull request was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)
