### PR TITLE
allow multiple substitutions in the quest title [requested changes implemented]

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/OsmElementQuestType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/OsmElementQuestType.kt
@@ -8,7 +8,7 @@ import de.westnordost.streetcomplete.data.osm.download.MapDataWithGeometryHandle
 
 interface OsmElementQuestType<T> : QuestType<T> {
 
-    fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String?> {
+    fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> {
         val name = tags["name"] ?: tags["brand"]
         return if (name != null) arrayOf(name) else arrayOf()
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
@@ -12,20 +12,20 @@ import java.util.*
 import java.util.concurrent.FutureTask
 
 fun Resources.getQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): String {
-    val name = getElementName(questType, element, configuration.locale, featureDictionaryFuture)
-    return getString(getQuestTitleResId(questType, element), name)
+    val arguments = getTemplateArguments(questType, element, configuration.locale, featureDictionaryFuture)
+    return getString(getQuestTitleResId(questType, element), *arguments)
 }
 
 fun Resources.getHtmlQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): Spanned {
-    val name = getElementName(questType, element, configuration.locale, featureDictionaryFuture)
-    val spanName = if (name != null) "<i>" + Html.escapeHtml(name) + "</i>" else null
-    return Html.fromHtml(getString(getQuestTitleResId(questType, element), spanName))
+    val arguments = getTemplateArguments(questType, element, configuration.locale, featureDictionaryFuture)
+    val spannedArguments = arguments.map {"<i>" + Html.escapeHtml(it) + "</i>"}.toTypedArray()
+    return Html.fromHtml(getString(getQuestTitleResId(questType, element), *spannedArguments))
 }
 
-private fun getElementName(questType: QuestType<*>, element: Element?, locale: Locale, featureDictionaryFuture: FutureTask<FeatureDictionary>?): String? {
+private fun getTemplateArguments(questType: QuestType<*>, element: Element?, locale: Locale, featureDictionaryFuture: FutureTask<FeatureDictionary>?): Array<String> {
     val tags = element?.tags
     val typeName = lazy {featureDictionaryFuture?.get()?.let { it.byTags(tags).forLocale(locale).find()?.firstOrNull()?.name }}
-    return ((questType as? OsmElementQuestType<*>)?.getTitleArgs(tags ?: emptyMap(), typeName) ?: arrayOf()).firstOrNull();
+    return ((questType as? OsmElementQuestType<*>)?.getTitleArgs(tags ?: emptyMap(), typeName)) ?: emptyArray()
 }
 
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -69,7 +69,7 @@ class AddPlaceName(
     override val icon = R.drawable.ic_quest_label
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_placeName_title_name
-    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>) = if (featureName.value == null) arrayOf() else arrayOf(featureName.value!!)
+    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>) = featureName.value?.let { arrayOf(it) } ?: arrayOf()
 
     override fun download(bbox: BoundingBox, handler: MapDataWithGeometryHandler): Boolean {
         val overpassQuery = bbox.toGlobalOverpassBBox() + "\n" + filter.toOverpassQLString() + getQuestPrintStatement()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -69,7 +69,7 @@ class AddPlaceName(
     override val icon = R.drawable.ic_quest_label
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_placeName_title_name
-    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>) = arrayOf(featureName.value)
+    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>) = if (featureName.value == null) arrayOf() else arrayOf(featureName.value!!)
 
     override fun download(bbox: BoundingBox, handler: MapDataWithGeometryHandler): Boolean {
         val overpassQuery = bbox.toGlobalOverpassBBox() + "\n" + filter.toOverpassQLString() + getQuestPrintStatement()

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddPostboxCollectionTimes.kt
@@ -35,7 +35,7 @@ class AddPostboxCollectionTimes(o: OverpassMapDataDao) : SimpleOverpassQuestType
         // apparently mostly not in Latin America and in Arabic world and unknown in Africa
     )
 
-    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String?> {
+    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> {
         val name = tags["name"] ?: tags["brand"] ?: tags["operator"]
         return if (name != null) arrayOf(name) else arrayOf()
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsUtil.kt
@@ -4,7 +4,7 @@ import android.view.View
 import de.westnordost.streetcomplete.data.QuestType
 
 fun genericQuestTitle(resourceProvider: View, type: QuestType<*>): String {
-    val questTitleTemplate = resourceProvider.resources.getString(type.title)
-    val parameterCount = questTitleTemplate.split("%s").size - 1
-    return resourceProvider.resources.getString(type.title, *Array(parameterCount){"…"})
+    // all parameters are replaced by generic three dots
+    // it is assumed that quests will not have a ridiculously huge parameter count
+    return resourceProvider.resources.getString(type.title, *Array(10){"…"})
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsUtil.kt
@@ -1,0 +1,10 @@
+package de.westnordost.streetcomplete.settings
+
+import android.view.View
+import de.westnordost.streetcomplete.data.QuestType
+
+fun genericQuestTitle(resourceProvider: View, type: QuestType<*>): String {
+    val questTitleTemplate = resourceProvider.resources.getString(type.title)
+    val parameterCount = questTitleTemplate.split("%s").size - 1
+    return resourceProvider.resources.getString(type.title, *Array(parameterCount){"…"})
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/ShowQuestFormsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/ShowQuestFormsActivity.kt
@@ -71,7 +71,7 @@ class ShowQuestFormsActivity : AppCompatActivity(), OsmQuestAnswerListener {
         private inner class ViewHolder(itemView: View) : ListAdapter.ViewHolder<QuestType<*>>(itemView) {
             override fun onBind(with: QuestType<*>) {
                 itemView.questIcon.setImageResource(with.icon)
-                itemView.questTitle.text = itemView.resources.getString(with.title, "…")
+                itemView.questTitle.text = genericQuestTitle(itemView, with)
                 itemView.setOnClickListener { onClickQuestType(with) }
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestSelectionAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestSelectionAdapter.kt
@@ -31,6 +31,7 @@ import androidx.recyclerview.widget.ItemTouchHelper.ACTION_STATE_DRAG
 import androidx.recyclerview.widget.ItemTouchHelper.ACTION_STATE_IDLE
 import androidx.recyclerview.widget.ItemTouchHelper.DOWN
 import androidx.recyclerview.widget.ItemTouchHelper.UP
+import de.westnordost.streetcomplete.settings.genericQuestTitle
 import kotlinx.android.synthetic.main.row_quest_selection.view.*
 
 class QuestSelectionAdapter @Inject constructor(
@@ -136,7 +137,7 @@ class QuestSelectionAdapter @Inject constructor(
             val colorResId = if (item.isInteractionEnabled) android.R.color.transparent else R.color.greyed_out
             itemView.setBackgroundResource(colorResId)
             questIcon.setImageResource(item.questType.icon)
-            questTitle.text = questTitle.resources.getString(item.questType.title, "…")
+            questTitle.text = genericQuestTitle(questTitle, item.questType)
             visibilityCheckBox.setOnCheckedChangeListener(null)
             visibilityCheckBox.isChecked = item.visible
             visibilityCheckBox.isEnabled = item.isInteractionEnabled


### PR DESCRIPTION
currently without influence on how app works, but I thought about

> Is \<info> accurate for \<name>?

(for this one I am currently testing a prototype)

or specify more info for opening hours quest

> What are the opening hours of \<name\> (\<object type>)


as currently I relatively often need to use Vespucci to check whatever what type of object is without OH. It is often necessary to locate it or confirm that it is actually gone.

-----

My work on this pull request was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)