### PR TITLE
On compass press, tilt map if not tilted, when not tracking location

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.graphics.PointF
 import android.hardware.SensorManager
 import android.location.Location
+import android.view.animation.DecelerateInterpolator
 import android.view.WindowManager
 import androidx.core.content.edit
 import com.mapzen.android.lost.api.LocationRequest
@@ -55,11 +56,14 @@ open class LocationAwareMapFragment : MapFragment() {
     private var zoomedYet = false
 
     /** Whether the view should automatically rotate with the compass (like during navigation) */
+    // Since the with-compass rotation happens with no animation, it's better to start the tilt
+    // animation abruptly and slide out, rather than sliding in and out (the default interpolator)
+    private val interpolator = DecelerateInterpolator()
     var isCompassMode: Boolean = false
         set(value) {
             field = value
             if (value) {
-                controller?.updateCameraPosition { tilt = PI.toFloat() / 5f }
+                controller?.updateCameraPosition(300, interpolator) { tilt = PI.toFloat() / 5f }
             }
         }
 


### PR DESCRIPTION
This implementation does not currently work because even when the tilt has been set to 0f, it usually reports being very slightly tilted (eg, tilt=5.317779E-7) and thus, isFlat is almost always false.

If you spam click the compass button, it will occasionally report `tilt=0f` and work properly. I'm not sure exactly why this is.