### PR TITLE
Disable auto-sync preference when not logged in

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
@@ -94,11 +94,11 @@ class SettingsFragment : PreferenceFragmentCompat(),
 
     override fun onStart() {
         super.onStart()
-        updateOsmAuthSummary()
+        updateOsmAuthDependentPrefs()
         activity?.setTitle(R.string.action_settings)
     }
 
-    private fun updateOsmAuthSummary() {
+    private fun updateOsmAuthDependentPrefs() {
         val oauth = preferenceScreen?.findPreference<Preference>("oauth")
         val username = prefs.getString(Prefs.OSM_USER_NAME, null)
         oauth?.summary = if (oAuth.isAuthorized) {
@@ -107,6 +107,8 @@ class SettingsFragment : PreferenceFragmentCompat(),
         } else {
             resources.getString(R.string.pref_title_not_authorized_summary2)
         }
+
+        findPreference<Preference>("autosync")?.setEnabled(oAuth.isAuthorized)
     }
 
     override fun onResume() {
@@ -122,7 +124,7 @@ class SettingsFragment : PreferenceFragmentCompat(),
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
         when(key) {
             Prefs.OAUTH_ACCESS_TOKEN_SECRET -> {
-                updateOsmAuthSummary()
+                updateOsmAuthDependentPrefs()
             }
             Prefs.SHOW_NOTES_NOT_PHRASED_AS_QUESTIONS -> {
                 val task = applyNoteVisibilityChangedTask.get()

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -6,6 +6,14 @@
         android:key="communication"
         android:title="@string/pref_category_communication">
 
+        <Preference
+            android:key="oauth"
+            android:title="@string/pref_title_authorization"
+            android:summary="@string/pref_title_not_authorized_summary2"
+            android:persistent="true"
+            android:widgetLayout="@layout/widget_image_open_in_browser"
+            />
+
         <ListPreference
             android:key="autosync"
             android:title="@string/pref_title_sync"
@@ -14,14 +22,6 @@
             android:entries="@array/pref_entries_autosync"
             android:entryValues="@array/pref_entryvalues_autosync"
             android:persistent="true"
-            />
-
-        <Preference
-            android:key="oauth"
-            android:title="@string/pref_title_authorization"
-            android:summary="@string/pref_title_not_authorized_summary2"
-            android:persistent="true"
-            android:widgetLayout="@layout/widget_image_open_in_browser"
             />
 
     </PreferenceCategory>


### PR DESCRIPTION
Also moved auto-sync preference below authorization preference, to reflect the hierarchy.

When not logged in, it's not possible to upload quest answers at all, so the auto-sync setting should have no effect. Thus, we should disable it in those situations.

If you don't agree, feel free to discuss and/or close this. I only opened it as a PR because it was barely more effort than opening an issue.

From what I read in #1557, it looks like the auto-sync preference *may* impact how often we bug users to log in (I have not looked at the code to confirm whether this is currently the case). I'd argue that auto-upload *should* not have any effect on how often we prompt for login. If it does, I'll add a follow up commit to address that (but that's more work, so I want to make sure you'd be interested in merging, first).