### PR TITLE
remove "show more" button from image selector form (#1692)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AImageListQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AImageListQuestAnswerFragment.kt
@@ -20,7 +20,7 @@ import kotlinx.android.synthetic.main.quest_generic_list.*
  * I is the type of each item in the image list (a simple model object). In MVC, this would
  * be the view model.
  *
- * T is the type of the answer object (also a simple model object) created by the quest 
+ * T is the type of the answer object (also a simple model object) created by the quest
  * form and consumed by the quest type. In MVC, this would be the model.
  */
 abstract class AImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnswerFragment<T>() {
@@ -34,8 +34,6 @@ abstract class AImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnswerFragm
     protected open val itemsPerRow = 4
     /** return -1 for any number. Default: 1  */
     protected open val maxSelectableItems = 1
-    /** return -1 for showing all items at once. Default: -1  */
-    protected open val maxNumberOfInitiallyShownItems = -1
     /** return true to move last picked items to the front. On by default. Only respected if the
      *  items do not all fit into one line */
     protected open val moveFavoritesToFront = true
@@ -70,20 +68,12 @@ abstract class AImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnswerFragm
             }
         })
 
-        showMoreButton.setOnClickListener {
-            imageSelector.items = moveFavouritesToFront(items)
-            showMoreButton.visibility = View.GONE
-        }
-
-        var initiallyShow = maxNumberOfInitiallyShownItems
+        showMoreButton.visibility = View.GONE
+        
+        imageSelector.items = moveFavouritesToFront(items)
         if (savedInstanceState != null) {
-            if (savedInstanceState.getBoolean(EXPANDED)) initiallyShow = -1
-            showItems(initiallyShow)
-
             val selectedIndices = savedInstanceState.getIntegerArrayList(SELECTED_INDICES)!!
             imageSelector.select(selectedIndices)
-        } else {
-            showItems(initiallyShow)
         }
         list.adapter = imageSelector
     }
@@ -102,19 +92,9 @@ abstract class AImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnswerFragm
         super.onSaveInstanceState(outState)
         // note: the view might be not available anymore at this point!
         outState.putIntegerArrayList(SELECTED_INDICES, ArrayList(imageSelector.selectedIndices))
-        outState.putBoolean(EXPANDED, showMoreButton?.visibility == View.GONE)
     }
 
     override fun isFormComplete() = imageSelector.selectedIndices.isNotEmpty()
-
-    private fun showItems(initiallyShow: Int) {
-        val allItems = items
-        val showAll = initiallyShow == -1 || initiallyShow >= allItems.size
-
-        showMoreButton.visibility = if(showAll) View.GONE else View.VISIBLE
-        val sortedItems = moveFavouritesToFront(allItems)
-        imageSelector.items = if(showAll) sortedItems else sortedItems.subList(0, initiallyShow)
-    }
 
     private fun moveFavouritesToFront(originalList: List<Item<I>>): List<Item<I>> {
         val result: LinkedList<Item<I>> = LinkedList(originalList)
@@ -127,6 +107,5 @@ abstract class AImageListQuestAnswerFragment<I,T> : AbstractQuestFormAnswerFragm
 
     companion object {
         private const val SELECTED_INDICES = "selected_indices"
-        private const val EXPANDED = "expanded"
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant/AddFireHydrantTypeForm.kt
@@ -14,7 +14,6 @@ class AddFireHydrantTypeForm : AImageListQuestAnswerFragment<String, String>() {
     )
 
     override val itemsPerRow = 2
-    override val maxNumberOfInitiallyShownItems = 2
 
     override fun onClickOk(selectedItems: List<String>) {
         applyAnswer(selectedItems.single())

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduceForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/orchard_produce/AddOrchardProduceForm.kt
@@ -75,7 +75,6 @@ class AddOrchardProduceForm : AImageListQuestAnswerFragment<String, List<String>
     override val items get() = countryInfo.orchardProduces.mapNotNull { producesMap[it] }
 
     override val itemsPerRow = 3
-    override val maxNumberOfInitiallyShownItems = -1
     override val maxSelectableItems = -1
 
     override fun onClickOk(selectedItems: List<String>) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/religion/AddReligionForm.kt
@@ -36,8 +36,6 @@ class AddReligionForm : AImageListQuestAnswerFragment<String,String>() {
         Item("caodaism",  R.drawable.ic_religion_caodaist,  R.string.quest_religion_caodaist) // Vietnam
     ).sortedBy(countryInfo.popularReligions)
 
-    override val maxNumberOfInitiallyShownItems = 4
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         imageSelector.cellLayoutId = R.layout.cell_icon_select_with_label_below

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/roof_shape/AddRoofShapeForm.kt
@@ -35,8 +35,6 @@ class AddRoofShapeForm : AImageListQuestAnswerFragment<String, String>() {
         Item("cone", R.drawable.ic_roof_cone)
     )
 
-    override val maxNumberOfInitiallyShownItems = 8
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         imageSelector.cellLayoutId = R.layout.cell_labeled_icon_select

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sport/AddSportForm.kt
@@ -57,7 +57,6 @@ class AddSportForm : AImageListQuestAnswerFragment<String, List<String>>() {
     ).sortedBy(countryInfo.popularSports)
 
     override val maxSelectableItems = -1
-    override val maxNumberOfInitiallyShownItems = 8
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
see https://github.com/westnordost/StreetComplete/issues/1692#issuecomment-585310314

The original reason to introduce this button was when the UI looked like this:

![image](https://user-images.githubusercontent.com/4661658/75807000-f5da1d80-5d84-11ea-9d39-19fd887bbd66.png)

The answer button bar always floated at the bottom of the screen. With the current UI, only the OK button always floats at the bottom while the other answers are at the end of the form. The problem with the old UI was that there was no clear indicator if the currently visible choices where the only choices or if there are more. To indicate that there is more, there was a slight fade-to-white at the bottom as can be seen here.

![image](https://user-images.githubusercontent.com/4661658/75807655-1060c680-5d86-11ea-9b99-4cf141f7861e.png)

But the more clear indicator that there is more was simply a button that is visible right when opening the form that says "show more".

The current UI does not have this problem because the answer button bar ("Can't say",...) is always at the bottom of of all choices and the end of the form is indicated by rounded corners at the bottom of the bubble dialog.

This show more button is used in situations where answer options were included that - looking at taginfo - were very unlikely to be chosen but were included for completeness sake. To not make the form unnecessarily long for 99% of answers and make users able to give a quick answer without scanning through the whole list, those unlikely answers are cut off.

The following quests have these cut-offs currently:
- **roof quest**: Roof shapes that make up less than 0.1% of tagged roof shapes are cut-off
- for the others, I don't have the numbers, but I think they are somewhat along these lines as well

Having read why they were introduced, what changed in the meantime and what purpose they (still) serve, do you think this PR should be merged, @smichel17 , @matkoniecz ?