### PR TITLE
increase contrast for orange text

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="accent">#ff6600</color>
+    <color name="accent_variant">#F44336</color>
+
     <color name="attribution_text">#ccc</color>
 
     <color name="hint_text">#999</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
 <resources>
     <color name="primary">#4141ba</color>
     <color name="primary_variant">#3939a3</color>
-    <color name="accent">#ff6600</color>
+    <color name="accent">#D14000</color>
     <color name="accent_variant">#F44336</color>
 
     <color name="on_primary">#fff</color>


### PR DESCRIPTION
related to #1872

> 1.4.3 Make text have more contrast, in particular, text buttons using the orange accent color. Maybe make the orange a little darker.

Current `#ff6600` orange vs `#ffffff` background has 2.94:1 contrast. Suggested contrast is 4.5:1, what would require making it noticeably darker (for example `#D14000`).

But it will in turn break contrast requirement in the dark mode where current one is sufficient.

So I changed contrast in light mode and copied current one to night mode.

I admit that despite claimed contract increase I see no change in visibility. I am not sure whatever I somehow fooled myself or maybe my eyes/phone are special.

Or tool/definitions of contrast are faulty here. Or maybe it actually increases visibility needed by people with worse eyesight.