### PR TITLE
prefer to show quests rather than labels

### DIFF
--- a/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
+++ b/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
@@ -58,7 +58,8 @@ layers:
             draw:
                 quest-icons:
                     interactive: true
-                    priority: function() { return feature.order }
+                    priority: 1
+                    order: function() { return feature.order }
                     size: 66px
                     sprite: function() { return feature.kind }
                     sprite_default: quest

--- a/app/src/main/java/de/westnordost/streetcomplete/map/QuestPinLayerManager.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/QuestPinLayerManager.kt
@@ -182,18 +182,21 @@ class QuestPinLayerManager @Inject constructor(
     }
 
     private fun getQuestDrawOrder(quest: Quest): Int {
-        /* priority is decided by
+        /* order is decided by
+           - minimalValue - minimum to ensure that quest labels will be placed in
+             preference to street labels etc
            - primarily by quest type to allow quest prioritization
            - for quests of the same type - influenced by quest id,
              this is done to reduce chance that as user zoom in a quest disappears,
              especially in case where disappearing quest is one that user selected to solve
              main priority part - values fit into Integer, but with as large steps as possible */
+        val minimalValue = 99999;
         val questTypeOrder = questTypeOrders[quest.type] ?: 0
-        val freeValuesForEachQuest = Int.MAX_VALUE / questTypeOrders.size
+        val freeValuesForEachQuest = (Int.MAX_VALUE - minimalValue) / questTypeOrders.size
         /* quest ID is used to add values unique to each quest to make ordering consistent
            freeValuesForEachQuest is an int, so % freeValuesForEachQuest will fit into int */
         val hopefullyUniqueValueForQuest = (quest.id!! % freeValuesForEachQuest).toInt()
-        return questTypeOrder * freeValuesForEachQuest + hopefullyUniqueValueForQuest
+        return minimalValue + questTypeOrder * freeValuesForEachQuest + hopefullyUniqueValueForQuest
     }
 
     companion object {


### PR DESCRIPTION
fixes #1905

And, yes apparently #1462 was pure placebo.

I still see some cases where quest icon should appear but is blocked by something, but this PR removes at least one bug and reduces how many spurious collisions are happening.

Thanks to @peternewman for report, thanks to @m-rey for a testing location.