### PR TITLE
give hint about repurposed buildings

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/AddBuildingTypeForm.kt
@@ -11,6 +11,7 @@ import de.westnordost.streetcomplete.quests.building_type.BuildingType.*
 class AddBuildingTypeForm : AGroupedImageListQuestAnswerFragment<String,String>() {
 
     override val otherAnswers = listOf(
+        OtherAnswer(R.string.quest_buildingType_answer_types_change_over_time) { showChangedPurposeHint() },
         OtherAnswer(R.string.quest_buildingType_answer_multiple_types) { showMultipleTypesHint() },
         OtherAnswer(R.string.quest_buildingType_answer_construction_site) { applyAnswer("construction") }
     )
@@ -40,6 +41,14 @@ class AddBuildingTypeForm : AGroupedImageListQuestAnswerFragment<String,String>(
             .setMessage(R.string.quest_buildingType_answer_multiple_types_description)
             .setPositiveButton(android.R.string.ok, null)
             .show()
+        }
+    }
+
+    private fun showChangedPurposeHint() {
+        activity?.let { AlertDialog.Builder(it)
+                .setMessage(R.string.quest_buildingType_answer_types_change_over_time_description)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -542,6 +542,8 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_generic_item_invalid_value">Please select a more specific value.</string>
     <string name="quest_buildingType_answer_multiple_types">It has multiple purposes</string>
     <string name="quest_buildingType_answer_multiple_types_description">Simply select the main purpose of this building. E.g. if there is a shop on the ground floor with apartments above it, it is still mainly an apartment building.</string>
+    <string name="quest_buildingType_answer_types_change_over_time">Purpose changed over time</string>
+    <string name="quest_buildingType_answer_types_change_over_time_description">Select the purpose defining the building. The question is about the current building form. It is not about its historical form, it is not about how building is used.\n\nChurch building used as a warehouse is still a church building.\nTrain station building that is now abandoned or housing a museum should be still marked as a train station.\nBut rebuilding may erase original form, for example factory may be rebuilt so extensively that the current form is now a residential building.</string>
     <string name="quest_buildingType_answer_construction_site">It is still being constructed</string>
 
 


### PR DESCRIPTION
implements part of #1913

"Can't say" menu would  have a new entry:

> Purpose changed over time</string>

with 

>Select the purpose defining the building. The question is about the current building form. It is not about its historical form, it is not about how building is used.
>
> Church building used as a warehouse is still a church building.
> Train station building that is now abandoned or housing a museum should be still marked as a train station.
> But rebuilding may erase original form, for example factory may be rebuilt so extensively that the current form is now a residential building.

shown