### PR TITLE
add alias to can't say about nonexisting objects [PR adding strings, not mergeable before v22]

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
@@ -186,6 +186,8 @@ abstract class AbstractQuestAnswerFragment<T> : AbstractBottomSheetFragment(), I
 
         val cantSay = OtherAnswer(R.string.quest_generic_answer_notApplicable) { onClickCantSay() }
         answers.add(cantSay)
+        val notExistingAnymore = OtherAnswer(R.string.quest_generic_answer_notExisting) { onClickNotExisting() }
+        answers.add(notExistingAnymore)
 
         val way = osmElement as? Way
         if (way != null) {
@@ -267,6 +269,15 @@ abstract class AbstractQuestAnswerFragment<T> : AbstractBottomSheetFragment(), I
         }
     }
 
+    protected fun onClickNotExisting() {
+        context?.let { AlertDialog.Builder(it)
+                .setTitle(R.string.quest_leave_new_note_title)
+                .setMessage(R.string.quest_leave_new_note_about_nonexisting_object_description)
+                .setNegativeButton(R.string.quest_leave_new_note_no) { _, _ -> skipQuest() }
+                .setPositiveButton(R.string.quest_leave_new_note_yes) { _, _ -> composeNote() }
+                .show()
+        }
+    }
     protected fun composeNote() {
         val questTitle = englishResources.getQuestTitle(questType, osmElement, featureDictionaryFuture)
         listener?.onComposeNote(questId, questGroup, questTitle)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="quest_leave_new_note_title">"Leave a note instead?"</string>
     <string name="quest_leave_new_note_description">"You can leave a public note at this location which other mappers can comment on and hopefully resolve or alternatively just hide the quest for yourself only"</string>
     <string name="quest_leave_new_note_request">"Please, leave a note"</string>
-    <string name="quest_leave_new_note_about_nonexisting_object_description">"Questions may be asked about objects that no longer exist. It happens when OpenStreetMap contains incorrect or outdated info. You can leave a public note at this location with an explanation of what is wrong or alternatively just hide the quest for yourself only."</string>
+    <string name="quest_leave_new_note_about_nonexisting_object_description">"Questions may be asked about objects that are not existing. It happens when OpenStreetMap contains incorrect or outdated info. You can leave a public note at this location with an explanation of what is wrong or alternatively just hide the quest for yourself only."</string>
     <string name="quest_leave_new_note_yes">"OK"</string>
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="quest_leave_new_note_title">"Leave a note instead?"</string>
     <string name="quest_leave_new_note_description">"You can leave a public note at this location which other mappers can comment on and hopefully resolve or alternatively just hide the quest for yourself only"</string>
     <string name="quest_leave_new_note_request">"Please, leave a note"</string>
-    <string name="quest_leave_new_note_about_nonexisting_object_description">"Questions may be asked about objects that are not existing. It happens when OpenStreetMap contains wrong or outdated info. You can leave a public note at this location with explanation what is wrong or alternatively just hide the quest for yourself only."</string>
+    <string name="quest_leave_new_note_about_nonexisting_object_description">"Questions may be asked about objects that no longer exist. It happens when OpenStreetMap contains incorrect or outdated info. You can leave a public note at this location with an explanation of what is wrong or alternatively just hide the quest for yourself only."</string>
     <string name="quest_leave_new_note_yes">"OK"</string>
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,12 +35,15 @@
     <string name="map_attribution_osm">"© OpenStreetMap contributors"</string>
     <string name="quest_generic_otherAnswers">"Other answers…"</string>
     <string name="quest_generic_answer_notApplicable">"Can’t say…"</string>
+    <string name="quest_generic_answer_notExisting">"Does not exist…"</string>
     <string name="quest_generic_confirmation_title">"Are you sure?"</string>
     <string name="quest_generic_confirmation_yes">"Yes, I am sure"</string>
     <string name="quest_generic_confirmation_no">"I will check"</string>
     <string name="quest_generic_error_field_empty">"You left this field empty"</string>
     <string name="quest_leave_new_note_title">"Leave a note instead?"</string>
     <string name="quest_leave_new_note_description">"You can leave a public note at this location which other mappers can comment on and hopefully resolve or alternatively just hide the quest for yourself only"</string>
+    <string name="quest_leave_new_note_request">"Please, leave a note"</string>
+    <string name="quest_leave_new_note_about_nonexisting_object_description">"Questions may be asked about objects that are not existing. It happens when OpenStreetMap contains wrong or outdated info. You can leave a public note at this location with explanation what is wrong or alternatively just hide the quest for yourself only."</string>
     <string name="quest_leave_new_note_yes">"OK"</string>
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="quest_leave_new_note_title">"Leave a note instead?"</string>
     <string name="quest_leave_new_note_description">"You can leave a public note at this location which other mappers can comment on and hopefully resolve or alternatively just hide the quest for yourself only"</string>
     <string name="quest_leave_new_note_request">"Please, leave a note"</string>
-    <string name="quest_leave_new_note_about_nonexisting_object_description">"Questions may be asked about objects that are not existing. It happens when OpenStreetMap contains incorrect or outdated info. You can leave a public note at this location with an explanation of what is wrong or alternatively just hide the quest for yourself only."</string>
+    <string name="quest_leave_new_note_about_nonexisting_object_description">"Questions may be asked about objects that do not exist. It happens when OpenStreetMap contains incorrect or outdated info. You can leave a public note at this location with an explanation of what is wrong or alternatively just hide the quest for yourself only."</string>
     <string name="quest_leave_new_note_yes">"OK"</string>
     <string name="quest_leave_new_note_no">"No, just hide"</string>
     <string name="quest_leave_new_note_photo">Attach photo</string>


### PR DESCRIPTION
It turns out that many users were especially confused about questions referring to nonexisting objects
and were unaware that the proper solution is to create a note (though many of them figured this out)
this change will guide them toward note feature as applicable in case of nonexisting objects

main negative is increased complexity and more work for translators but as this confusion
is quite widespread (mentioned both in talks with more experienced mappers and revealed
in testing with newbies) it seems to be a worth doing

fixes #1673 fixes #1097 using a different method