### PR TITLE
WIP: Position gps button to left of zoom controls

### DIFF
--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -103,37 +103,47 @@
             android:layout_alignParentBottom="true"
             android:layout_alignParentRight="true"
             android:layout_marginBottom="22dp"
-            android:orientation="vertical"
             android:clipToPadding="false"
             tools:ignore="RtlHardcoded,RtlSymmetry">
-
-            <ImageButton
-                android:id="@+id/zoomInButton"
-                android:layout_width="@dimen/map_button_size"
-                android:layout_height="@dimen/map_button_size"
-                android:scaleType="center"
-                style="@style/RoundWhiteButton"
-                android:src="@drawable/ic_zoom_plus_black_24dp"
-                android:contentDescription="@string/map_btn_zoom_in"/>
-
-            <ImageButton
-                android:id="@+id/zoomOutButton"
-                android:layout_width="@dimen/map_button_size"
-                android:layout_height="@dimen/map_button_size"
-                android:scaleType="center"
-                style="@style/RoundWhiteButton"
-                android:src="@drawable/ic_zoom_minus_black_24dp"
-                android:contentDescription="@string/map_btn_zoom_out"/>
 
             <de.westnordost.streetcomplete.location.LocationStateButton
                 android:id="@+id/gpsTrackingButton"
                 android:layout_width="@dimen/map_button_size"
                 android:layout_height="@dimen/map_button_size"
+                android:layout_gravity="bottom"
                 android:scaleType="center"
                 style="@style/RoundWhiteButton"
                 android:src="@drawable/ic_location_24dp"
                 app:tint="@color/activated_tint"
                 android:contentDescription="@string/map_btn_gps_tracking"/>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:orientation="vertical"
+                android:clipToPadding="false"
+                >
+
+                <ImageButton
+                    android:id="@+id/zoomInButton"
+                    android:layout_width="@dimen/map_button_size"
+                    android:layout_height="@dimen/map_button_size"
+                    android:scaleType="center"
+                    style="@style/RoundWhiteButton"
+                    android:src="@drawable/ic_zoom_plus_black_24dp"
+                    android:contentDescription="@string/map_btn_zoom_in"/>
+
+                <ImageButton
+                    android:id="@+id/zoomOutButton"
+                    android:layout_width="@dimen/map_button_size"
+                    android:layout_height="@dimen/map_button_size"
+                    android:scaleType="center"
+                    style="@style/RoundWhiteButton"
+                    android:src="@drawable/ic_zoom_minus_black_24dp"
+                    android:contentDescription="@string/map_btn_zoom_out"/>
+
+            </LinearLayout>
 
         </LinearLayout>
 


### PR DESCRIPTION
Context in commit message (where it belongs), copied here (for ease of access):

> When gps is enabled and the button disappears, it's awkward to have an
empty space below the zoom buttons. This moves the gps button to the
side and shifts the zoom buttons down, forming a .: shape. This way,
when the gps button disappears, the zoom buttons sit nicely at the
bottom.
> 
> This is a proof of concept implementation; it has an awkward interaction
with the "off screen" location pin, since the wrapping LinearLayout is
bigger than the visible buttons, so the pin is shown prematurely.

Looks like this:

![Screenshot from 2020-06-26 11-17-46](https://user-images.githubusercontent.com/6563664/85874120-aa2f0200-b7c1-11ea-88d4-753b614d21d9.png)

I'll fix the pin interaction if you're interested in merging.

…and, uh, ignore the branch name :smile: I was originally going to propose an orthogonal set of changes but then decided to do this first.