### PR TITLE
show icons where possible, fix #1927

### DIFF
--- a/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
+++ b/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
@@ -58,7 +58,7 @@ layers:
             draw:
                 quest-icons:
                     interactive: true
-                    priority: 10 #hack, but having priority 2 here and 1 for dots causes icons to be blocked by dots displayed for the same object (despite "collide: false")
+                    priority: 0
                     order: function() { return feature.order }
                     size: 66px
                     sprite: function() { return feature.kind }
@@ -69,6 +69,7 @@ layers:
             draw:
                 quest-dots:
                     priority: 1
+                    order: 1
                     size: 16px
                     collide: false
                     offset: [-2.5px, -22px]

--- a/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
+++ b/app/src/main/assets/map_theme/jawg/streetcomplete.yaml
@@ -58,7 +58,7 @@ layers:
             draw:
                 quest-icons:
                     interactive: true
-                    priority: 1
+                    priority: 10 #hack, but having priority 2 here and 1 for dots causes icons to be blocked by dots displayed for the same object (despite "collide: false")
                     order: function() { return feature.order }
                     size: 66px
                     sprite: function() { return feature.kind }
@@ -68,6 +68,7 @@ layers:
             filter: { $zoom: { min: 16 } }
             draw:
                 quest-dots:
+                    priority: 1
                     size: 16px
                     collide: false
                     offset: [-2.5px, -22px]
@@ -75,6 +76,8 @@ layers:
             filter: { $zoom: { min: 13, max: 15.999 } }
             draw:
                 quest-dots:
+                    priority: 1
+                    order: 1
                     size: 16px
                     collide: true
                     offset: [-2.5px, -22px]


### PR DESCRIPTION
https://github.com/westnordost/StreetComplete/pull/1930#issuecomment-651145134

<s>having priority 2 for icons and 1 for dots causes icons to be blocked
priority 10 for icons and 1 for dots works, at least on Xiaomi hardware

I have no idea what is happening here and I sytongly suspect that
my testing may be somehow wrong, independent confirmation would be welcomed
see #1927 report with info how this may be triggered

I suspect that this hack may be a bit fragile, real fix would be nice

Yes, setting `order` for dots/quest-dots sounds like a proper fix,
but it is not working (dots still block icons)

I also tested replacing `function() { return feature.order }` by some
constant (1, 10, 100, 1000, 10000) - it failed to change behavior,
so bad order value assigned there appears to not be the reason.</s>