### PR TITLE
Add "new quest" label to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/quest-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/quest-suggestion.md
@@ -1,6 +1,7 @@
 ---
 name: Quest suggestion
 about: Suggest a new question to ask the user about
+labels: new quest
 
 ---
 


### PR DESCRIPTION
This change automates adding the "new quest" label to quest suggestions added via the respective issue template.

I've seen you reverted a similar change for the feature request template: https://github.com/westnordost/StreetComplete/commit/14a2f9a271889d12dfcadcbabdd3bbde56154808

But it is used in the bug report template: https://github.com/westnordost/StreetComplete/blob/v21.0/.github/ISSUE_TEMPLATE/bug_report.md