### PR TITLE
Don't enter addresses in Luxembourg

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -28,6 +28,7 @@ class AddHousenumber(private val overpass: OverpassMapDataAndGeometryApi) : OsmE
 
     // See overview here: https://ent8r.github.io/blacklistr/?streetcomplete=housenumber/AddHousenumber.kt
     override val enabledInCountries = AllCountriesExcept(
+            "LU", // placeholder
             "NL", // https://forum.openstreetmap.org/viewtopic.php?id=60356
             "DK", // https://lists.openstreetmap.org/pipermail/talk-dk/2017-November/004898.html
             "NO", // https://forum.openstreetmap.org/viewtopic.php?id=60357

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddHousenumber.kt
@@ -28,7 +28,7 @@ class AddHousenumber(private val overpass: OverpassMapDataAndGeometryApi) : OsmE
 
     // See overview here: https://ent8r.github.io/blacklistr/?streetcomplete=housenumber/AddHousenumber.kt
     override val enabledInCountries = AllCountriesExcept(
-            "LU", // placeholder
+            "LU", // https://github.com/westnordost/StreetComplete/pull/1943
             "NL", // https://forum.openstreetmap.org/viewtopic.php?id=60356
             "DK", // https://lists.openstreetmap.org/pipermail/talk-dk/2017-November/004898.html
             "NO", // https://forum.openstreetmap.org/viewtopic.php?id=60357


### PR DESCRIPTION
Please disable the adding of addresses in Luxembourg for now. The Luxembourg community is [working on a conflation](https://github.com/osmlu/addresses-tools) of the [official addresses database](https://github.com/osmlu/csventrifuge), and having new addresses with just the house number popping up is making our manual work (even) harder.