### PR TITLE
Update Cash Acceptance Quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -36,6 +36,12 @@ class AddAcceptsCash(o: OverpassMapDataAndGeometryApi) : SimpleOverpassQuestType
           or tourism ~ ${tourism.joinToString("|")}
         )
         and name and !payment:cash and !payment:coins and !payment:notes
+        and (
+          tourism !~ attraction|gallery|museum 
+          or (
+            tourism ~ attraction|gallery|museum and fee = yes
+          )
+        )
     """
     override val commitMessage = "Add whether this place accepts cash as payment"
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -13,9 +13,12 @@ class AddAcceptsCash(o: OverpassMapDataAndGeometryApi) : SimpleOverpassQuestType
         "restaurant", "cinema", "nightclub", "planetarium", "theatre", "marketplace",
         "internet_cafe", "car_wash", "fuel", "pharmacy", "telephone", "vending_machine"
     )
-    private val tourism = listOf(
-        "zoo", "aquarium", "theme_park", "museum", "hotel", "hostel", "motel", "guest_house",
-        "apartment", "camp_site", "attraction", "gallery"
+    private val tourismWithoutImpliedFees = listOf(
+        "zoo", "aquarium", "theme_park", "hotel", "hostel", "motel", "guest_house",
+        "apartment", "camp_site"
+    )
+    private val tourismWithImpliedFees = listOf(
+        "attraction", "museum", "gallery" 
     )
     private val leisure = listOf(
         "adult_gaming_centre", "amusement_arcade", "bowling_alley", "escape_game", "miniature_golf",
@@ -33,15 +36,10 @@ class AddAcceptsCash(o: OverpassMapDataAndGeometryApi) : SimpleOverpassQuestType
           or amenity ~ ${amenity.joinToString("|")}
           or leisure ~ ${leisure.joinToString("|")}
           or craft ~ ${craft.joinToString("|")}
-          or tourism ~ ${tourism.joinToString("|")}
+          or tourism ~ ${tourismWithoutImpliedFees.joinToString("|")}
+          or tourism ~ ${tourismWithImpliedFees.joinToString("|")} and fee = yes
         )
         and name and !payment:cash and !payment:coins and !payment:notes
-        and (
-          tourism !~ attraction|gallery|museum 
-          or (
-            tourism ~ attraction|gallery|museum and fee = yes
-          )
-        )
     """
     override val commitMessage = "Add whether this place accepts cash as payment"
     override val defaultDisabledMessage = R.string.default_disabled_msg_go_inside

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -11,13 +11,15 @@ class AddAcceptsCash(o: OverpassMapDataAndGeometryApi) : SimpleOverpassQuestType
     private val amenity = listOf(
         "bar", "cafe", "fast_food", "food_court", "ice_cream", "pub", "biergarten",
         "restaurant", "cinema", "nightclub", "planetarium", "theatre", "marketplace",
-        "internet_cafe", "car_wash", "fuel", "pharmacy"
+        "internet_cafe", "car_wash", "fuel", "pharmacy", "telephone", "vending_machine"
     )
     private val tourism = listOf(
-        "zoo", "aquarium", "theme_park", "museum"
+        "zoo", "aquarium", "theme_park", "museum", "hotel", "hostel", "motel", "guest_house",
+        "apartment", "camp_site", "attraction", "gallery"
     )
     private val leisure = listOf(
-        "tanning_salon"
+        "adult_gaming_centre", "amusement_arcade", "bowling_alley", "escape_game", "miniature_golf",
+        "sauna", "trampoline_park", "tanning_salon"
     )
     private val craft = listOf(
         "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
@@ -42,7 +44,7 @@ class AddAcceptsCash(o: OverpassMapDataAndGeometryApi) : SimpleOverpassQuestType
 
     override val enabledInCountries = NoCountriesExcept(
             // Europe
-            "SE"
+            "DE", "GB", "IE", "NL", "SE"
     )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_accepts_cash_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -44,7 +44,7 @@ class AddAcceptsCash(o: OverpassMapDataAndGeometryApi) : SimpleOverpassQuestType
 
     override val enabledInCountries = NoCountriesExcept(
             // Europe
-            "DE", "GB", "IE", "NL", "SE"
+            "SE"
     )
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_accepts_cash_title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/accepts_cash/AddAcceptsCash.kt
@@ -13,11 +13,11 @@ class AddAcceptsCash(o: OverpassMapDataAndGeometryApi) : SimpleOverpassQuestType
         "restaurant", "cinema", "nightclub", "planetarium", "theatre", "marketplace",
         "internet_cafe", "car_wash", "fuel", "pharmacy", "telephone", "vending_machine"
     )
-    private val tourismWithoutImpliedFees = listOf(
+    private val tourismWithImpliedFees = listOf(
         "zoo", "aquarium", "theme_park", "hotel", "hostel", "motel", "guest_house",
         "apartment", "camp_site"
     )
-    private val tourismWithImpliedFees = listOf(
+    private val tourismWithoutImpliedFees = listOf(
         "attraction", "museum", "gallery" 
     )
     private val leisure = listOf(
@@ -36,8 +36,8 @@ class AddAcceptsCash(o: OverpassMapDataAndGeometryApi) : SimpleOverpassQuestType
           or amenity ~ ${amenity.joinToString("|")}
           or leisure ~ ${leisure.joinToString("|")}
           or craft ~ ${craft.joinToString("|")}
-          or tourism ~ ${tourismWithoutImpliedFees.joinToString("|")}
-          or tourism ~ ${tourismWithImpliedFees.joinToString("|")} and fee = yes
+          or tourism ~ ${tourismWithImpliedFees.joinToString("|")}
+          or tourism ~ ${tourismWithoutImpliedFees.joinToString("|")} and fee = yes
         )
         and name and !payment:cash and !payment:coins and !payment:notes
     """


### PR DESCRIPTION
~~The quest "Does X accept cash payment?" is currently only active in Sweden as per #1573 and #1743.~~

~~This PR aims to activate this quest in Great Britain, Ireland, The Netherlands and Germany, with the first three being countries that have a much higher card acceptance, the latter having made quite some drastic changes during the CoVID-19 pandemic with quite a few places stopping to accept cash payment in favour of card payments.~~ (DE unlikely to be accepted by the community for spam reasons, GB, IE, NL need further investigation)

I also added a few place types that could be interesting to see the answer for (e.g. there have been quite a few vending machines in recent months that got put up in places around Germany that did not accept cash anymore).

Discussion is of course always welcome :-)

Kai
