### PR TITLE
Use Compat classes.

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/AboutFragment.kt
@@ -2,7 +2,6 @@ package de.westnordost.streetcomplete.about
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -10,6 +9,7 @@ import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toUri
+import androidx.core.widget.TextViewCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.recyclerview.widget.RecyclerView
@@ -135,9 +135,7 @@ class AboutFragment : PreferenceFragmentCompat() {
                 itemView.imageView.setImageResource(with.iconId)
                 itemView.textView.text = with.title
                 itemView.setOnClickListener { openUrl(with.url) }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    itemView.textView.setTextAppearance(R.style.TextAppearance_Title)
-                }
+                TextViewCompat.setTextAppearance(itemView.textView, R.style.TextAppearance_Title)
             }
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/about/CreditsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/CreditsFragment.kt
@@ -1,14 +1,14 @@
 package de.westnordost.streetcomplete.about
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.LinearLayout
 import android.widget.TextView
-
+import androidx.core.widget.TextViewCompat
+import androidx.fragment.app.Fragment
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.ktx.getYamlObject
 import kotlinx.android.synthetic.main.fragment_credits.*
@@ -45,7 +45,7 @@ class CreditsFragment : Fragment(R.layout.fragment_credits) {
     private fun addContributorsTo(contributors: List<String>, view: ViewGroup) {
         val items = contributors.map { "<li>$it</li>" }.joinToString("")
         val textView = HtmlTextView(activity)
-        textView.setTextAppearance(activity, R.style.TextAppearance_Body)
+        TextViewCompat.setTextAppearance(textView, R.style.TextAppearance_Body)
         textView.setTextIsSelectable(true)
         textView.setHtml("<ul>$items</ul>")
         view.addView(textView, LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT))

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
@@ -1,13 +1,11 @@
 package de.westnordost.streetcomplete.quests
 
-import android.content.ContextWrapper
-import androidx.annotation.AnyThread
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Bundle
 import android.text.Html
-import androidx.appcompat.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.View
@@ -15,30 +13,30 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.Button
 import android.widget.PopupMenu
+import androidx.annotation.AnyThread
+import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.core.view.isGone
+import androidx.core.text.HtmlCompat
 import com.google.android.flexbox.FlexboxLayout
-
-import java.lang.ref.WeakReference
-import java.util.Locale
-
-import javax.inject.Inject
-
 import de.westnordost.osmapi.map.data.OsmElement
 import de.westnordost.osmapi.map.data.Way
 import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.Injector
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.meta.CountryInfo
+import de.westnordost.streetcomplete.data.meta.CountryInfos
+import de.westnordost.streetcomplete.data.osm.elementgeometry.ElementGeometry
 import de.westnordost.streetcomplete.data.quest.Quest
 import de.westnordost.streetcomplete.data.quest.QuestGroup
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
-import de.westnordost.streetcomplete.data.meta.CountryInfo
-import de.westnordost.streetcomplete.data.meta.CountryInfos
-import de.westnordost.streetcomplete.data.osm.elementgeometry.ElementGeometry
 import de.westnordost.streetcomplete.ktx.isArea
 import kotlinx.android.synthetic.main.fragment_quest_answer.*
+import java.lang.ref.WeakReference
+import java.util.*
 import java.util.concurrent.FutureTask
+import javax.inject.Inject
 
 /** Abstract base class for any bottom sheet with which the user answers a specific quest(ion)  */
 abstract class AbstractQuestAnswerFragment<T> : AbstractBottomSheetFragment(), IsShowingQuestDetails {
@@ -237,7 +235,8 @@ abstract class AbstractQuestAnswerFragment<T> : AbstractBottomSheetFragment(), I
         val houseNumber = tags["addr:housenumber"]
 
         if (houseName != null) {
-            return Html.fromHtml(resources.getString(R.string.at_housename, "<i>" + Html.escapeHtml(houseName) + "</i>"))
+            return HtmlCompat.fromHtml(resources.getString(R.string.at_housename, "<i>" + Html.escapeHtml(houseName) + "</i>"),
+                HtmlCompat.FROM_HTML_MODE_LEGACY)
         }
         if (conscriptionNumber != null) {
             if (streetNumber != null) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
@@ -3,11 +3,11 @@ package de.westnordost.streetcomplete.quests
 import android.content.res.Resources
 import android.text.Html
 import android.text.Spanned
-
+import androidx.core.text.HtmlCompat
 import de.westnordost.osmapi.map.data.Element
 import de.westnordost.osmfeatures.FeatureDictionary
-import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmElementQuestType
+import de.westnordost.streetcomplete.data.quest.QuestType
 import java.util.*
 import java.util.concurrent.FutureTask
 
@@ -19,7 +19,8 @@ fun Resources.getQuestTitle(questType: QuestType<*>, element: Element?, featureD
 fun Resources.getHtmlQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): Spanned {
     val arguments = getTemplateArguments(questType, element, configuration.locale, featureDictionaryFuture)
     val spannedArguments = arguments.map {"<i>" + Html.escapeHtml(it) + "</i>"}.toTypedArray()
-    return Html.fromHtml(getString(getQuestTitleResId(questType, element), *spannedArguments))
+    return HtmlCompat.fromHtml(getString(getQuestTitleResId(questType, element), *spannedArguments),
+        HtmlCompat.FROM_HTML_MODE_LEGACY)
 }
 
 private fun getTemplateArguments(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import android.text.Html
 import android.text.Spanned
 import androidx.core.os.ConfigurationCompat
+import androidx.core.os.LocaleListCompat
 import androidx.core.text.HtmlCompat
 import de.westnordost.osmapi.map.data.Element
 import de.westnordost.osmfeatures.FeatureDictionary
@@ -13,14 +14,14 @@ import java.util.*
 import java.util.concurrent.FutureTask
 
 fun Resources.getQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): String {
-    val locale = ConfigurationCompat.getLocales(configuration)[0]
-    val arguments = getTemplateArguments(questType, element, locale, featureDictionaryFuture)
+    val localeList = ConfigurationCompat.getLocales(configuration)
+    val arguments = getTemplateArguments(questType, element, localeList, featureDictionaryFuture)
     return getString(getQuestTitleResId(questType, element), *arguments)
 }
 
 fun Resources.getHtmlQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): Spanned {
-    val locale = ConfigurationCompat.getLocales(configuration)[0]
-    val arguments = getTemplateArguments(questType, element, locale, featureDictionaryFuture)
+    val localeList = ConfigurationCompat.getLocales(configuration)
+    val arguments = getTemplateArguments(questType, element, localeList, featureDictionaryFuture)
     val spannedArguments = arguments.map {"<i>" + Html.escapeHtml(it) + "</i>"}.toTypedArray()
     return HtmlCompat.fromHtml(getString(getQuestTitleResId(questType, element), *spannedArguments),
         HtmlCompat.FROM_HTML_MODE_LEGACY)
@@ -29,16 +30,35 @@ fun Resources.getHtmlQuestTitle(questType: QuestType<*>, element: Element?, feat
 private fun getTemplateArguments(
     questType: QuestType<*>,
     element: Element?,
-    locale: Locale,
+    localeList: LocaleListCompat,
     featureDictionaryFuture: FutureTask<FeatureDictionary>?
 ): Array<String> {
     val tags = element?.tags ?: emptyMap()
-    val typeName = lazy { featureDictionaryFuture?.get()?.let { dict ->
-        dict.byTags(tags).forLocale(locale).find()?.firstOrNull()?.name
-    }}
+    val typeName = lazy { findTypeName(tags, featureDictionaryFuture, localeList) }
     return ((questType as? OsmElementQuestType<*>)?.getTitleArgs(tags, typeName)) ?: emptyArray()
 }
 
+private fun findTypeName(
+    tags: Map<String, String>,
+    featureDictionaryFuture: FutureTask<FeatureDictionary>?,
+    localeList: LocaleListCompat
+): String? {
+    featureDictionaryFuture?.get()?.let { dict ->
+        localeList.forEach { locale ->
+            val matches = dict.byTags(tags).forLocale(locale).find()
+            if (matches.isNotEmpty()) {
+                return matches.first().name
+            }
+        }
+    }
+    return null
+}
+
+private inline fun LocaleListCompat.forEach(action: (Locale) -> Unit) {
+    for (i in 0 until size()) {
+        action(this[i])
+    }
+}
 
 private fun getQuestTitleResId(questType: QuestType<*>, element: Element?) =
     (questType as? OsmElementQuestType<*>)?.getTitle(element?.tags ?: emptyMap()) ?: questType.title

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.quests
 import android.content.res.Resources
 import android.text.Html
 import android.text.Spanned
+import androidx.core.os.ConfigurationCompat
 import androidx.core.text.HtmlCompat
 import de.westnordost.osmapi.map.data.Element
 import de.westnordost.osmfeatures.FeatureDictionary
@@ -12,12 +13,14 @@ import java.util.*
 import java.util.concurrent.FutureTask
 
 fun Resources.getQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): String {
-    val arguments = getTemplateArguments(questType, element, configuration.locale, featureDictionaryFuture)
+    val locale = ConfigurationCompat.getLocales(configuration)[0]
+    val arguments = getTemplateArguments(questType, element, locale, featureDictionaryFuture)
     return getString(getQuestTitleResId(questType, element), *arguments)
 }
 
 fun Resources.getHtmlQuestTitle(questType: QuestType<*>, element: Element?, featureDictionaryFuture: FutureTask<FeatureDictionary>?): Spanned {
-    val arguments = getTemplateArguments(questType, element, configuration.locale, featureDictionaryFuture)
+    val locale = ConfigurationCompat.getLocales(configuration)[0]
+    val arguments = getTemplateArguments(questType, element, locale, featureDictionaryFuture)
     val spannedArguments = arguments.map {"<i>" + Html.escapeHtml(it) + "</i>"}.toTypedArray()
     return HtmlCompat.fromHtml(getString(getQuestTitleResId(questType, element), *spannedArguments),
         HtmlCompat.FROM_HTML_MODE_LEGACY)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
+import androidx.core.text.HtmlCompat
 import de.westnordost.osmapi.map.data.LatLon
 import de.westnordost.streetcomplete.Injector
 import de.westnordost.streetcomplete.R
@@ -108,11 +109,11 @@ class AddAddressStreetForm : AbstractQuestFormAnswerFragment<AddressStreetAnswer
     }
 
     private fun confirmPossibleAbbreviation(name: String, onConfirmed: () -> Unit) {
-        val title = Html.fromHtml(
+        val title = HtmlCompat.fromHtml(
             resources.getString(
                 R.string.quest_streetName_nameWithAbbreviations_confirmation_title_name,
                 "<i>" + Html.escapeHtml(name) + "</i>"
-            )
+            ), HtmlCompat.FROM_HTML_MODE_LEGACY
         )
 
         AlertDialog.Builder(requireContext())

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/localized_name/AAddLocalizedNameForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/localized_name/AAddLocalizedNameForm.kt
@@ -3,24 +3,21 @@ package de.westnordost.streetcomplete.quests.localized_name
 import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings
-import androidx.appcompat.app.AlertDialog
-import androidx.recyclerview.widget.LinearLayoutManager
 import android.text.Html
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.core.text.HtmlCompat
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-
-import java.util.ArrayList
-import java.util.Queue
-
-import javax.inject.Inject
-
 import de.westnordost.streetcomplete.Injector
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.ktx.toObject
 import de.westnordost.streetcomplete.quests.AbstractQuestFormAnswerFragment
 import de.westnordost.streetcomplete.util.AdapterDataChangedWatcher
 import de.westnordost.streetcomplete.util.Serializer
-import de.westnordost.streetcomplete.ktx.toObject
+import java.util.*
+import javax.inject.Inject
 
 abstract class AAddLocalizedNameForm<T> : AbstractQuestFormAnswerFragment<T>() {
 
@@ -118,11 +115,11 @@ abstract class AAddLocalizedNameForm<T> : AbstractQuestFormAnswerFragment<T>() {
     }
 
     protected fun confirmPossibleAbbreviation(name: String, onConfirmed: () -> Unit) {
-        val title = Html.fromHtml(
+        val title = HtmlCompat.fromHtml(
             resources.getString(
                 R.string.quest_streetName_nameWithAbbreviations_confirmation_title_name,
                 "<i>" + Html.escapeHtml(name) + "</i>"
-            )
+            ), HtmlCompat.FROM_HTML_MODE_LEGACY
         )
 
         AlertDialog.Builder(requireContext())


### PR DESCRIPTION
Make use of more of Jetpack's `Compat` classes, such as [`HtmlCompat`](https://developer.android.com/reference/androidx/core/text/HtmlCompat) and [`ConfigurationCompat`](https://developer.android.com/reference/kotlin/androidx/core/os/ConfigurationCompat), to avoid deprecation warnings with `Html`, `Configuration` and `TextView`.