### PR TITLE
Use more KTX extensions.

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractQuestAnswerFragment.kt
@@ -16,8 +16,8 @@ import android.widget.PopupMenu
 import androidx.annotation.AnyThread
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
+import androidx.core.text.parseAsHtml
 import androidx.core.view.isGone
-import androidx.core.text.HtmlCompat
 import com.google.android.flexbox.FlexboxLayout
 import de.westnordost.osmapi.map.data.OsmElement
 import de.westnordost.osmapi.map.data.Way
@@ -235,8 +235,8 @@ abstract class AbstractQuestAnswerFragment<T> : AbstractBottomSheetFragment(), I
         val houseNumber = tags["addr:housenumber"]
 
         if (houseName != null) {
-            return HtmlCompat.fromHtml(resources.getString(R.string.at_housename, "<i>" + Html.escapeHtml(houseName) + "</i>"),
-                HtmlCompat.FROM_HTML_MODE_LEGACY)
+            return resources.getString(R.string.at_housename, "<i>" + Html.escapeHtml(houseName) + "</i>")
+                .parseAsHtml()
         }
         if (conscriptionNumber != null) {
             if (streetNumber != null) {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestUtil.kt
@@ -5,7 +5,7 @@ import android.text.Html
 import android.text.Spanned
 import androidx.core.os.ConfigurationCompat
 import androidx.core.os.LocaleListCompat
-import androidx.core.text.HtmlCompat
+import androidx.core.text.parseAsHtml
 import de.westnordost.osmapi.map.data.Element
 import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmElementQuestType
@@ -23,8 +23,7 @@ fun Resources.getHtmlQuestTitle(questType: QuestType<*>, element: Element?, feat
     val localeList = ConfigurationCompat.getLocales(configuration)
     val arguments = getTemplateArguments(questType, element, localeList, featureDictionaryFuture)
     val spannedArguments = arguments.map {"<i>" + Html.escapeHtml(it) + "</i>"}.toTypedArray()
-    return HtmlCompat.fromHtml(getString(getQuestTitleResId(questType, element), *spannedArguments),
-        HtmlCompat.FROM_HTML_MODE_LEGACY)
+    return getString(getQuestTitleResId(questType, element), *spannedArguments).parseAsHtml()
 }
 
 private fun getTemplateArguments(

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/address/AddAddressStreetForm.kt
@@ -7,7 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
-import androidx.core.text.HtmlCompat
+import androidx.core.text.parseAsHtml
 import de.westnordost.osmapi.map.data.LatLon
 import de.westnordost.streetcomplete.Injector
 import de.westnordost.streetcomplete.R
@@ -109,12 +109,10 @@ class AddAddressStreetForm : AbstractQuestFormAnswerFragment<AddressStreetAnswer
     }
 
     private fun confirmPossibleAbbreviation(name: String, onConfirmed: () -> Unit) {
-        val title = HtmlCompat.fromHtml(
-            resources.getString(
-                R.string.quest_streetName_nameWithAbbreviations_confirmation_title_name,
-                "<i>" + Html.escapeHtml(name) + "</i>"
-            ), HtmlCompat.FROM_HTML_MODE_LEGACY
-        )
+        val title = resources.getString(
+            R.string.quest_streetName_nameWithAbbreviations_confirmation_title_name,
+            "<i>" + Html.escapeHtml(name) + "</i>"
+        ).parseAsHtml()
 
         AlertDialog.Builder(requireContext())
             .setTitle(title)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/localized_name/AAddLocalizedNameForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/localized_name/AAddLocalizedNameForm.kt
@@ -7,7 +7,7 @@ import android.text.Html
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
-import androidx.core.text.HtmlCompat
+import androidx.core.text.parseAsHtml
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import de.westnordost.streetcomplete.Injector
@@ -115,12 +115,10 @@ abstract class AAddLocalizedNameForm<T> : AbstractQuestFormAnswerFragment<T>() {
     }
 
     protected fun confirmPossibleAbbreviation(name: String, onConfirmed: () -> Unit) {
-        val title = HtmlCompat.fromHtml(
-            resources.getString(
-                R.string.quest_streetName_nameWithAbbreviations_confirmation_title_name,
-                "<i>" + Html.escapeHtml(name) + "</i>"
-            ), HtmlCompat.FROM_HTML_MODE_LEGACY
-        )
+        val title = resources.getString(
+            R.string.quest_streetName_nameWithAbbreviations_confirmation_title_name,
+            "<i>" + Html.escapeHtml(name) + "</i>"
+        ).parseAsHtml()
 
         AlertDialog.Builder(requireContext())
             .setTitle(title)


### PR DESCRIPTION
* Use the [`String.parseAsHtml()`](https://developer.android.com/reference/kotlin/androidx/core/text/package-summary#(kotlin.String).parseAsHtml(kotlin.Int,%20android.text.Html.ImageGetter,%20android.text.Html.TagHandler)) extension function instead of `HtmlCompat.fromHtml()`.
* Use the [`lifecycleScope`](https://developer.android.com/reference/kotlin/androidx/lifecycle/package-summary#(androidx.lifecycle.LifecycleOwner).lifecycleScope:androidx.lifecycle.LifecycleCoroutineScope) extension property.