### PR TITLE
Use variables for multi-dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,6 +84,12 @@ configurations {
     compile.exclude group: 'org.intellij', module:'annotations'
 }
 
+ext {
+    mockito_version = '2.28.2'
+    kotlinx_version = '1.3.8'
+    dagger_version = '2.14.1'
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -92,18 +98,18 @@ dependencies {
 
     // tests
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'org.mockito:mockito-inline:2.28.2'
+    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
     testImplementation 'org.assertj:assertj-core:2.8.0'
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'org.mockito:mockito-android:2.28.2'
+    androidTestImplementation "org.mockito:mockito-android:$mockito_version"
     androidTestImplementation 'org.assertj:assertj-core:2.8.0'
 
     // dependency injection
-    implementation 'com.google.dagger:dagger:2.14.1'
-    kapt 'com.google.dagger:dagger-compiler:2.14.1'
+    implementation "com.google.dagger:dagger:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
     // Android stuff
     implementation 'com.google.android.material:material:1.2.0'
@@ -122,8 +128,8 @@ dependencies {
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.8'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinx_version"
 
     // scheduling background jobs
     implementation "androidx.work:work-runtime:2.4.0"


### PR DESCRIPTION
Some dependencies like kotlinx, mockito and dagger have multiple
dependencies defined which should be the same version. This ensures they
are kept the same by using a variable to define the version for these
dependencies.