### PR TITLE
ask about defibrilator opening hours - fixes #1756

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -84,6 +84,9 @@ class AddOpeningHours (
                 // common
                 "carpenter", "shoemaker", "tailor", "photographer", "dressmaker",
                 "electronics_repair", "key_cutter", "stonemason"
+            ),
+            "emergency" to arrayOf(
+                "defibrillator"
             )
         ).map { it.key + " ~ " + it.value.joinToString("|") }.joinToString("\n or ") + "\n" + """
             )
@@ -92,7 +95,7 @@ class AddOpeningHours (
           or opening_hours older today -${r * 1} years
         )
         and (access !~ private|no)
-        and (name or brand or noname = yes)
+        and (name or brand or noname = yes or emergency=defibrillator)
         and opening_hours:signed != no
         """.trimIndent()
     )}


### PR DESCRIPTION
it asks in standard opening hours quest
it was proposed in #1756 to ask also about access,
but I think that it does not qualify for SC quest as
such defibrillators are extremely rare and will be
indirectly asked by opening hour quest, what should
catch this rare cases

Other option would be to make this a separate quest with own special title/icon.

![Screenshot_2020-09-03-20-30-15-244_de westnordost streetcomplete debug](https://user-images.githubusercontent.com/899988/92153428-8cff5b00-ee24-11ea-8405-3465b1aaf75c.png)
