### PR TITLE
[WIP] add quest presets

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/Prefs.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/Prefs.java
@@ -31,6 +31,7 @@ public class Prefs
 	// not shown anywhere directly
 	public static final String
 			QUEST_ORDER = "quests.order",
+			QUEST_PRESET = "quests.preset",
 			QUEST_INVALIDATION = "quests.invalidation",
 			LAST_SOLVED_QUEST_TIME = "changesets.lastQuestSolvedTime",
 			MAP_LATITUDE = "map.latitude",

--- a/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/VisibleQuestTypeDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/visiblequests/VisibleQuestTypeDao.kt
@@ -5,6 +5,9 @@ import androidx.core.content.contentValuesOf
 
 import javax.inject.Inject
 
+import android.content.SharedPreferences
+import de.westnordost.streetcomplete.Prefs
+import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.visiblequests.QuestVisibilityTable.Columns.QUEST_TYPE
 import de.westnordost.streetcomplete.data.visiblequests.QuestVisibilityTable.Columns.VISIBILITY
@@ -15,41 +18,52 @@ import de.westnordost.streetcomplete.ktx.query
 import javax.inject.Singleton
 
 /** Stores which quest types are visible by user selection and which are not */
-@Singleton class VisibleQuestTypeDao @Inject constructor(private val dbHelper: SQLiteOpenHelper) {
+@Singleton class VisibleQuestTypeDao @Inject constructor(private val prefs: SharedPreferences, private val dbHelper: SQLiteOpenHelper) {
 
     /* Is a singleton because it has a in-memory cache that is synchronized with changes made on
        the DB */
 
-    private val cache: MutableMap<String, Boolean> by lazy { loadQuestTypeVisibilities() }
+    @Inject internal lateinit var questTypeRegistry: QuestTypeRegistry
+
+    private val cache: MutableMap<String, Int> by lazy { loadQuestTypeVisibilities() }
 
     private val db get() = dbHelper.writableDatabase
 
-    private fun loadQuestTypeVisibilities(): MutableMap<String, Boolean> {
-        val result = mutableMapOf<String,Boolean>()
+    private fun loadQuestTypeVisibilities(): MutableMap<String, Int> {
+        val result = mutableMapOf<String,Int>()
         db.query(NAME) { cursor ->
             val questTypeName = cursor.getString(QUEST_TYPE)
-            val visible = cursor.getInt(VISIBILITY) != 0
-            result[questTypeName] = visible
+            result[questTypeName] = cursor.getInt(VISIBILITY)
         }
         return result
     }
 
     @Synchronized fun isVisible(questType: QuestType<*>): Boolean {
+        val preset = prefs.getString(Prefs.QUEST_PRESET,null)?.toIntOrNull() ?: 0
         val questTypeName = questType.javaClass.simpleName
-        return cache[questTypeName] ?: (questType.defaultDisabledMessage <= 0)
+        return ((cache[questTypeName] ?: 0) shr preset) % 2 != 0 ?: (questType.defaultDisabledMessage <= 0)
     }
 
     @Synchronized fun setVisible(questType: QuestType<*>, visible: Boolean) {
+        val preset = prefs.getString(Prefs.QUEST_PRESET,null)?.toIntOrNull() ?: 0
         val questTypeName = questType.javaClass.simpleName
+        if (visible == isVisible(questType)) return
+        val oldVis = cache[questTypeName] ?: 0
+        val newVis =
+            if ((oldVis shr preset) % 2 != 0)
+                oldVis - (1 shl preset)
+            else
+                oldVis + (1 shl preset)
         db.replaceOrThrow(NAME, null, contentValuesOf(
             QUEST_TYPE to questTypeName,
-            VISIBILITY to if (visible) 1 else 0
+            VISIBILITY to newVis
         ))
-        cache[questTypeName] = visible
+        cache[questTypeName] = newVis
     }
 
     @Synchronized fun clear() {
-        db.delete(NAME, null, null)
-        cache.clear()
+        for (questType in questTypeRegistry.all) {
+            setVisible(questType, questType.defaultDisabledMessage <= 0)
+        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/SettingsFragment.kt
@@ -18,6 +18,7 @@ import de.westnordost.streetcomplete.data.download.tiles.DownloadedTilesDao
 import de.westnordost.streetcomplete.data.osm.osmquest.OsmQuestController
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuest
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestController
+import de.westnordost.streetcomplete.data.visiblequests.QuestTypeOrderList
 import de.westnordost.streetcomplete.data.user.UserController
 import de.westnordost.streetcomplete.ktx.toast
 import kotlinx.coroutines.*
@@ -33,6 +34,7 @@ class SettingsFragment : PreferenceFragmentCompat(),
     @Inject internal lateinit var downloadedTilesDao: DownloadedTilesDao
     @Inject internal lateinit var osmQuestController: OsmQuestController
     @Inject internal lateinit var osmNoteQuestController: OsmNoteQuestController
+    @Inject internal lateinit var questTypeOrderList: QuestTypeOrderList
 
     interface Listener {
         fun onClickedQuestSelection()
@@ -124,6 +126,9 @@ class SettingsFragment : PreferenceFragmentCompat(),
                 val theme = Prefs.Theme.valueOf(prefs.getString(Prefs.THEME_SELECT, "AUTO")!!)
                 AppCompatDelegate.setDefaultNightMode(theme.appCompatNightMode)
                 activity?.recreate()
+            }
+            Prefs.QUEST_PRESET -> {
+                questTypeOrderList.reload()
             }
         }
     }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -12,6 +12,18 @@
         <item>OFF</item>
     </string-array>
 
+    <string-array name="pref_entries_preset_select" translatable="false">
+        <item>"preset1"</item>
+        <item>"preset2"</item>
+        <item>"preset3"</item>
+    </string-array>
+
+    <string-array name="pref_entryvalues_preset_select" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
     <string-array name="pref_entries_resurvey_intervals">
         <item>@string/resurvey_intervals_less_often</item>
         <item>@string/resurvey_intervals_default</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -29,6 +29,16 @@
             />
 
         <ListPreference
+            android:key="quests.preset"
+            android:title="select preset"
+            android:summary="%s"
+            android:defaultValue="0"
+            android:entries="@array/pref_entries_preset_select"
+            android:entryValues="@array/pref_entryvalues_preset_select"
+            android:persistent="true"
+            />
+
+        <ListPreference
             android:key="quests.resurveyIntervals"
             android:title="@string/pref_title_resurvey_intervals"
             android:summary="%s"


### PR DESCRIPTION
Since I really want to have quest presets (#1654), I tried adding them myself...

This PR adds working presets (each has its own quest order and visibility), but there is still a lot to be done (help is appreciated):
* by default, no quest is visible (not even notes). A manual reset of the quest list is necessary
* currently there are 3 presets, and no way to add, remove or rename anything
* the preset names are directly in the arrays.xml instead of using stings (I was lazy, easy to fix)
* I basically have no experience with coding other than pushing around huge amounts of numbers, so it's probably a good idea to be suspicious about *everything* in this PR

How it works:
* Quest order: there is now one orderList for each preset. The orderLists are stored in the same *QUEST_ORDER* string as previously, and use `+` as a separator. The list is reloaded when the preset is changed.
* Quest visibility: the database is the same, but in the cache *int* instead of *boolean* is used, because visibilies for all presets are stored in one *int* (one visibility per bit, and the preset determines which bit to use)