### PR TITLE
Antialias pointer pin drawable

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/map/PointerPinView.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/PointerPinView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Outline
+import android.graphics.Paint
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.util.AttributeSet
@@ -29,6 +30,10 @@ class PointerPinView @JvmOverloads constructor(
 
     private val pointerPin: Drawable = context.resources.getDrawable(R.drawable.quest_pin_pointer)
     private var pointerPinBitmap: Bitmap? = null
+    private val antiAliasPaint: Paint = Paint().apply {
+        isAntiAlias = true
+        isFilterBitmap = true
+    }
 
     /** rotation of the pin in degrees. Similar to rotation, only that the pointy end of the pin
      *  is always located at the edge of the view */
@@ -111,7 +116,7 @@ class PointerPinView @JvmOverloads constructor(
         val r = pinRotation
 
         c.withRotation(r, width/2f, height/2f) {
-            pointerPinBitmap?.let { canvas.drawBitmap(it, 0f, 0f, null) }
+            pointerPinBitmap?.let { canvas.drawBitmap(it, 0f, 0f, antiAliasPaint) }
         }
 
         val icon = pinIconDrawable


### PR DESCRIPTION
**Background:**
Currently the pointer pin looks jagged when rotating the map.

**Modifications:**
* Create a new paint in `PointerPinView` to enable anti-aliasing. Use it
when rendering the pointer pin drawable.


### Before:
![Screenshot_1600054720](https://user-images.githubusercontent.com/1526881/93041595-bf1d7380-f601-11ea-9675-70afeb8178c1.png)


### After:
![Screenshot_1600054672](https://user-images.githubusercontent.com/1526881/93041599-c04ea080-f601-11ea-9b30-3418c60fcf8c.png)

