### PR TITLE
Multiple collection times on the same weekdays as selected before

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddCollectionTimesForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddCollectionTimesForm.kt
@@ -1,9 +1,11 @@
 package de.westnordost.streetcomplete.quests.postbox_collection_times
 
 import android.os.Bundle
+import android.view.Menu
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.View
+import androidx.appcompat.widget.PopupMenu
 import androidx.recyclerview.widget.RecyclerView
 
 import java.util.ArrayList
@@ -52,7 +54,29 @@ class AddCollectionTimesForm : AbstractQuestFormAnswerFragment<CollectionTimesAn
         collectionTimesList.isNestedScrollingEnabled = false
         checkIsFormComplete()
 
-        addTimesButton.setOnClickListener { collectionTimesAdapter.addNew() }
+        addTimesButton.setOnClickListener { onClickAddButton(it) }
+    }
+
+    private fun onClickAddButton(v: View) {
+        val rows = collectionTimesAdapter.collectionTimesRows
+
+        val addTimeAvailable = rows.isNotEmpty() && rows.last() is WeekdaysTimesRow
+
+        if (addTimeAvailable) {
+            val popup = PopupMenu(requireContext(), v)
+            if (addTimeAvailable) popup.menu.add(Menu.NONE, 0, Menu.NONE, R.string.quest_openingHours_add_hours)
+            popup.menu.add(Menu.NONE, 1, Menu.NONE, R.string.quest_openingHours_add_weekdays)
+            popup.setOnMenuItemClickListener { item ->
+                when(item.itemId) {
+                    0 -> collectionTimesAdapter.addNewHours()
+                    1 -> collectionTimesAdapter.addNewWeekdays()
+                }
+                true
+            }
+            popup.show()
+        } else {
+            collectionTimesAdapter.addNewWeekdays()
+        }
     }
 
     private fun loadCollectionTimesData(savedInstanceState: Bundle?):List<WeekdaysTimesRow> =

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddCollectionTimesForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/AddCollectionTimesForm.kt
@@ -60,7 +60,7 @@ class AddCollectionTimesForm : AbstractQuestFormAnswerFragment<CollectionTimesAn
     private fun onClickAddButton(v: View) {
         val rows = collectionTimesAdapter.collectionTimesRows
 
-        val addTimeAvailable = rows.isNotEmpty() && rows.last() is WeekdaysTimesRow
+        val addTimeAvailable = rows.isNotEmpty()
 
         if (addTimeAvailable) {
             val popup = PopupMenu(requireContext(), v)

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAdapter.kt
@@ -64,10 +64,22 @@ class CollectionTimesAdapter(
     }
 
     fun addNew() {
+        addNewWeekdays()
+    }
+
+    fun addNewWeekdays() {
         val isFirst = collectionTimesRows.isEmpty()
         openSetWeekdaysDialog(getWeekdaysSuggestion(isFirst)) { weekdays ->
             openSetTimeDialog(12 * 60) { minutes ->
                 add(weekdays, minutes) }
+        }
+    }
+
+    fun addNewHours() {
+        val rowAbove = if (collectionTimesRows.size > 0) collectionTimesRows[collectionTimesRows.size - 1] else null
+        if (rowAbove !is WeekdaysTimesRow) return
+        openSetTimeDialog(12 * 60) { minutes ->
+            add(rowAbove.weekdays, minutes)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/postbox_collection_times/CollectionTimesAdapter.kt
@@ -63,10 +63,6 @@ class CollectionTimesAdapter(
         if (position < collectionTimesRows.size) notifyItemChanged(position)
     }
 
-    fun addNew() {
-        addNewWeekdays()
-    }
-
     fun addNewWeekdays() {
         val isFirst = collectionTimesRows.isEmpty()
         openSetWeekdaysDialog(getWeekdaysSuggestion(isFirst)) { weekdays ->
@@ -77,7 +73,7 @@ class CollectionTimesAdapter(
 
     fun addNewHours() {
         val rowAbove = if (collectionTimesRows.size > 0) collectionTimesRows[collectionTimesRows.size - 1] else null
-        if (rowAbove !is WeekdaysTimesRow) return
+        if (rowAbove == null) return
         openSetTimeDialog(12 * 60) { minutes ->
             add(rowAbove.weekdays, minutes)
         }


### PR DESCRIPTION
Closes #2108.

Quest for adding collection times to `amenity=post_box` nodes was changed.

Just like the quest for adding opening times, this quest will now, if there already is a row, ask if you want to add a collection time to the same weekday(s) as the row before or if you want to add more weekdays.

`CollectionTimesAdapter.addNew()` was intentionally left in the code (I'm not sure if Android Studio correctly finds all references) bur calls `addNewWeekdays()`. If this should be removed, please advise @westnordost.