### PR TITLE
Remove warehouses and barns from building levels quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_levels/AddBuildingLevels.kt
@@ -35,5 +35,5 @@ private val BUILDINGS_WITH_LEVELS = arrayOf(
     "house","residential","apartments","detached","terrace","dormitory","semi",
     "semidetached_house","bungalow","school","civic","college","university","public",
     "hospital","kindergarten","transportation","train_station", "hotel","retail",
-    "commercial","office","warehouse","industrial","manufacture","parking","farm",
-    "farm_auxiliary","barn","cabin")
+    "commercial","office","industrial","manufacture","parking","farm","farm_auxiliary",
+    "cabin")


### PR DESCRIPTION
From my experience these types of buildings usually have levels indistinguishable from outside so asking for them is counterproductive and violates quest guidelines about being answerable without entering someone's property.