### PR TITLE
Reorder the step quests for optimal gathering

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestModule.kt
@@ -185,9 +185,9 @@ object QuestModule
         MarkCompletedBuildingConstruction(o, r),
         AddGeneralFee(o),
         AddSelfServiceLaundry(o),
-        AddStepCount(o), // before handrail so the surveyor doesn't need to walk it twice
-        AddHandrail(o, r), // for accessibility of pedestrian routing
-        AddStepsIncline(o),
+        AddStepsIncline(o), // can be gathered while walking perpendicular to the way e.g. the other side of the road or when running/cycling past
+        AddHandrail(o, r), // for accessibility of pedestrian routing, can be gathered when walking past
+        AddStepCount(o), // can only be gathered when walking along this way, also needs the most effort and least useful
         AddInformationToTourism(o),
 
         // ↓ 8. defined in the wiki, but not really used by anyone yet. Just collected for


### PR DESCRIPTION
Even if not travelling along the way itself.

Similar to #1583 I think this ordering will get the most step data gathered by the largest group of people.