### PR TITLE
Untested: Improve the username matching in the changelog

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/about/ChangelogFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/ChangelogFragment.kt
@@ -80,7 +80,7 @@ private fun addedLinks(description: String): String {
             val issue = matchResult.groupValues[1]
             "<a href=\"https://github.com/westnordost/StreetComplete/issues/$issue\">#$issue</a>"
         }
-        .replace(Regex("(?<=[\\s(]|^)@([a-zA-Z\d-]+)")) { matchResult ->
+        .replace(Regex("(?<=[\\s(]|^)@([a-zA-Z\\d-]+)")) { matchResult ->
             val contributor = matchResult.groupValues[1]
             "<a href=\"https://github.com/$contributor\">@$contributor</a>"
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/about/ChangelogFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/ChangelogFragment.kt
@@ -76,15 +76,12 @@ private fun readChangelog(resources: Resources) =
 
 private fun addedLinks(description: String): String {
     return description
-        .replace(Regex("([\\s,(])#([0-9]+)")) { matchResult ->
-            val s = matchResult.groupValues[1]
-            val issue = matchResult.groupValues[2]
-            "$s<a href=\"https://github.com/westnordost/StreetComplete/issues/$issue\">#$issue</a>"
+        .replace(Regex("(?<=[\\s(]|^)#(\\d+)")) { matchResult ->
+            val issue = matchResult.groupValues[1]
+            "<a href=\"https://github.com/westnordost/StreetComplete/issues/$issue\">#$issue</a>"
         }
-        .replace(Regex("([\\s,(])@(\\w[\\-\\w]*)([\\s,.\\)']|$)")) { matchResult ->
-            val s = matchResult.groupValues[1]
-            val contributor = matchResult.groupValues[2]
-            val e = matchResult.groupValues[3]
-            "$s<a href=\"https://github.com/$contributor\">@$contributor</a>$e"
+        .replace(Regex("(?<=[\\s(]|^)@([a-zA-Z\d-]+)")) { matchResult ->
+            val contributor = matchResult.groupValues[1]
+            "<a href=\"https://github.com/$contributor\">@$contributor</a>"
         }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/about/ChangelogFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/ChangelogFragment.kt
@@ -81,7 +81,7 @@ private fun addedLinks(description: String): String {
             val issue = matchResult.groupValues[2]
             "$s<a href=\"https://github.com/westnordost/StreetComplete/issues/$issue\">#$issue</a>"
         }
-        .replace(Regex("([\\s,(])@(\\w[\\-\\w]*)([\\s,.\\)]|$)")) { matchResult ->
+        .replace(Regex("([\\s,(])@(\\w[\\-\\w]*)([\\s,.\\)']|$)")) { matchResult ->
             val s = matchResult.groupValues[1]
             val contributor = matchResult.groupValues[2]
             val e = matchResult.groupValues[3]

--- a/app/src/main/java/de/westnordost/streetcomplete/about/ChangelogFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/about/ChangelogFragment.kt
@@ -76,14 +76,15 @@ private fun readChangelog(resources: Resources) =
 
 private fun addedLinks(description: String): String {
     return description
-        .replace(Regex("([\\s,(])#([0-9]*)")) { matchResult ->
+        .replace(Regex("([\\s,(])#([0-9]+)")) { matchResult ->
             val s = matchResult.groupValues[1]
             val issue = matchResult.groupValues[2]
             "$s<a href=\"https://github.com/westnordost/StreetComplete/issues/$issue\">#$issue</a>"
         }
-        .replace(Regex("([\\s,(])@(\\w*)")) { matchResult ->
+        .replace(Regex("([\\s,(])@(\\w[\\-\\w]*)([\\s,.\\)]|$)")) { matchResult ->
             val s = matchResult.groupValues[1]
             val contributor = matchResult.groupValues[2]
-            "$s<a href=\"https://github.com/$contributor\">@$contributor</a>"
+            val e = matchResult.groupValues[3]
+            "$s<a href=\"https://github.com/$contributor\">@$contributor</a>$e"
         }
 }


### PR DESCRIPTION
I've only checked the regex here: https://www.regexplanet.com/advanced/java/index.html

There's a stricter regex here:
https://github.com/shinnn/github-username-regex#githubusernameregex

Currently @CJ-Malone's mention doesn't work in v24.1