### PR TITLE
WIP: Add initial Room support.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
-import java.util.Properties
-import java.net.URI
 import java.io.FileInputStream
+import java.net.URI
+import java.util.*
 
 plugins {
     id("com.android.application")
@@ -38,6 +38,16 @@ android {
         versionCode = 2501
         versionName = "25.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments += arrayOf(
+                    "room.schemaLocation" to "$projectDir/schemas",
+                    "room.incremental" to "true",
+                    "room.expandProjection" to "true"
+                )
+            }
+        }
     }
 
     buildTypes {
@@ -99,6 +109,7 @@ dependencies {
     val mockitoVersion = "2.28.2"
     val kotlinxVersion = "1.3.8"
     val daggerVersion = "2.14.1"
+    val roomVersion = "2.2.5"
 
     // debugging
     debugImplementation("com.squareup.leakcanary:leakcanary-android:2.4")
@@ -129,6 +140,11 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.1.0")
     implementation("androidx.viewpager:viewpager:1.0.0")
     implementation("androidx.localbroadcastmanager:localbroadcastmanager:1.0.0")
+
+    // SQLite persistence
+    implementation("androidx.room:room-runtime:$roomVersion")
+    kapt("androidx.room:room-compiler:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
 
     // photos
     implementation("androidx.exifinterface:exifinterface:1.3.0")

--- a/app/src/main/java/de/westnordost/streetcomplete/data/AppDatabase.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/AppDatabase.kt
@@ -4,10 +4,18 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import de.westnordost.streetcomplete.ApplicationConstants
+import de.westnordost.streetcomplete.data.model.*
 
 // The database version is incremented to preserve the existing data when migrating from SQLite.
-@Database(entities = [], version = 17)
+@Database(
+    entities = [
+        ElementGeometry::class, OsmQuest::class, UndoOsmQuest::class, Node::class, Way::class
+    ],
+    version = 17
+)
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     companion object {
         @Volatile

--- a/app/src/main/java/de/westnordost/streetcomplete/data/AppDatabase.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/AppDatabase.kt
@@ -1,0 +1,38 @@
+package de.westnordost.streetcomplete.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import de.westnordost.streetcomplete.ApplicationConstants
+
+// The database version is incremented to preserve the existing data when migrating from SQLite.
+@Database(entities = [], version = 17)
+abstract class AppDatabase : RoomDatabase() {
+    companion object {
+        @Volatile
+        private var instance: AppDatabase? = null
+
+        @JvmStatic
+        fun getInstance(context: Context): AppDatabase {
+            var result = instance
+            if (result == null) {
+                synchronized(AppDatabase::class) {
+                    result = instance
+                    if (result == null) {
+                        instance = Room.databaseBuilder(context, AppDatabase::class.java, ApplicationConstants.DATABASE_NAME)
+                            .addMigrations(
+                                MIGRATION_1_3, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
+                                MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
+                                MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13,
+                                MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17
+                            )
+                            .build()
+                        result = instance
+                    }
+                }
+            }
+            return result!!
+        }
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/Converters.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/Converters.kt
@@ -1,0 +1,62 @@
+package de.westnordost.streetcomplete.data
+
+import androidx.room.TypeConverter
+import de.westnordost.streetcomplete.data.model.LatLon
+import de.westnordost.streetcomplete.data.osm.changes.StringMapChanges
+import de.westnordost.streetcomplete.data.quest.QuestStatus
+import de.westnordost.streetcomplete.ktx.toObject
+import java.util.*
+import kotlin.collections.ArrayList
+import kotlin.collections.HashMap
+
+object Converters {
+    private val serializer = DbModule.serializer()
+
+    @JvmStatic
+    @TypeConverter
+    fun dateToTimestamp(date: Date) = date.time
+
+    @JvmStatic
+    @TypeConverter
+    fun timestampToDate(timestamp: Long) = Date(timestamp)
+
+    @JvmStatic
+    @TypeConverter
+    fun polylinesToBlob(polylines: List<List<LatLon>>) = serializer.toBytes(ArrayList(polylines))
+
+    @JvmStatic
+    @TypeConverter
+    fun blobToPolylines(blob: ByteArray): List<List<LatLon>> = serializer.toObject<ArrayList<ArrayList<LatLon>>>(blob)
+
+    @JvmStatic
+    @TypeConverter
+    fun questTypeToString(questStatus: QuestStatus) = questStatus.name
+
+    @JvmStatic
+    @TypeConverter
+    fun stringToQuestType(string: String) = QuestStatus.valueOf(string)
+
+    @JvmStatic
+    @TypeConverter
+    fun stringMapChangesToBlob(stringMapChanges: StringMapChanges?) = stringMapChanges?.let { serializer.toBytes(it) }
+
+    @JvmStatic
+    @TypeConverter
+    fun blobToStringMapChanges(blob: ByteArray?) = blob?.let { serializer.toObject<StringMapChanges>(it) }
+
+    @JvmStatic
+    @TypeConverter
+    fun tagsToBlob(tags: Map<String, String>?) = tags?.let { serializer.toBytes(HashMap(it)) }
+
+    @JvmStatic
+    @TypeConverter
+    fun blobToTags(blob: ByteArray?): Map<String, String>? = blob?.let { serializer.toObject<HashMap<String, String>>(it) }
+
+    @JvmStatic
+    @TypeConverter
+    fun nodeIdsToBlob(nodeIds: List<Long>) = serializer.toBytes(ArrayList(nodeIds))
+
+    @JvmStatic
+    @TypeConverter
+    fun blobToNodeIds(blob: ByteArray): List<Long> = serializer.toObject<ArrayList<Long>>(blob)
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/Migrations.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/Migrations.kt
@@ -1,0 +1,187 @@
+package de.westnordost.streetcomplete.data
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import de.westnordost.osmapi.map.data.Element
+import de.westnordost.streetcomplete.data.notifications.NewUserAchievementsTable
+import de.westnordost.streetcomplete.data.osm.mapdata.RelationTable
+import de.westnordost.streetcomplete.data.osm.osmquest.OsmQuestTable
+import de.westnordost.streetcomplete.data.osm.osmquest.undo.UndoOsmQuestTable
+import de.westnordost.streetcomplete.data.osm.splitway.OsmQuestSplitWayTable
+import de.westnordost.streetcomplete.data.osm.upload.changesets.OpenChangesetsTable
+import de.westnordost.streetcomplete.data.osmnotes.createnotes.CreateNoteTable
+import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestTable
+import de.westnordost.streetcomplete.data.user.CountryStatisticsTable
+import de.westnordost.streetcomplete.data.user.achievements.UserAchievementsTable
+import de.westnordost.streetcomplete.data.user.achievements.UserLinksTable
+import de.westnordost.streetcomplete.data.visiblequests.QuestVisibilityTable
+import de.westnordost.streetcomplete.ktx.hasColumn
+import de.westnordost.streetcomplete.quests.oneway_suspects.AddSuspectedOneway
+import de.westnordost.streetcomplete.quests.oneway_suspects.data.WayTrafficFlowTable
+import de.westnordost.streetcomplete.quests.road_name.data.RoadNamesTable
+
+val MIGRATION_1_3 = object : Migration(1, 3) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(OpenChangesetsTable.CREATE)
+    }
+}
+
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        val tableName = OsmQuestTable.NAME
+        val oldTableName = tableName + "_old"
+        database.execSQL("ALTER TABLE $tableName RENAME TO $oldTableName")
+        database.execSQL(OsmQuestTable.CREATE_DB_VERSION_3)
+        val allColumns = OsmQuestTable.ALL_COLUMNS_DB_VERSION_3.joinToString(",")
+        database.execSQL("INSERT INTO $tableName ($allColumns) SELECT $allColumns FROM $oldTableName")
+        database.execSQL("DROP TABLE $oldTableName")
+
+        database.execSQL(OpenChangesetsTable.CREATE)
+    }
+}
+
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        if (!database.hasColumn(OsmQuestTable.NAME, OsmQuestTable.Columns.CHANGES_SOURCE)) {
+            database.execSQL("""
+                ALTER TABLE ${OsmQuestTable.NAME}
+                ADD COLUMN ${OsmQuestTable.Columns.CHANGES_SOURCE} varchar(255);
+                """.trimIndent()
+            )
+        }
+        database.execSQL("""
+            UPDATE ${OsmQuestTable.NAME}
+            SET ${OsmQuestTable.Columns.CHANGES_SOURCE} = 'survey'
+            WHERE ${OsmQuestTable.Columns.CHANGES_SOURCE} ISNULL;
+            """.trimIndent()
+        )
+
+        // sqlite does not support dropping/altering constraints. Need to create new table.
+        // For simplicity sake, we just drop the old table and create it anew, this has the
+        // effect that all currently open changesets will not be used but instead new ones are
+        // created. That's okay because OSM server closes open changesets after 1h automatically.
+        database.execSQL("DROP TABLE ${OpenChangesetsTable.NAME};")
+        database.execSQL(OpenChangesetsTable.CREATE)
+    }
+}
+
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("""
+            ALTER TABLE ${CreateNoteTable.NAME}
+            ADD COLUMN ${CreateNoteTable.Columns.QUEST_TITLE} text;
+            """.trimIndent()
+        )
+    }
+}
+
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(RoadNamesTable.CREATE)
+    }
+}
+
+val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(UndoOsmQuestTable.CREATE)
+        database.execSQL(UndoOsmQuestTable.MERGED_VIEW_CREATE)
+    }
+}
+
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("""
+            ALTER TABLE ${CreateNoteTable.NAME}
+            ADD COLUMN ${CreateNoteTable.Columns.IMAGE_PATHS} blob;
+            """.trimIndent()
+        )
+        database.execSQL("""
+            ALTER TABLE ${OsmNoteQuestTable.NAME}
+            ADD COLUMN ${OsmNoteQuestTable.Columns.IMAGE_PATHS} blob;
+            """.trimIndent()
+        )
+    }
+}
+
+val MIGRATION_8_9 = object : Migration(8, 9) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(QuestVisibilityTable.CREATE)
+    }
+}
+
+val MIGRATION_9_10 = object : Migration(9, 10) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(WayTrafficFlowTable.CREATE)
+    }
+}
+
+val MIGRATION_10_11 = object : Migration(10, 11) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        val where = OsmQuestTable.Columns.QUEST_TYPE + " = ?"
+        val args = arrayOf(AddSuspectedOneway::class.java.simpleName)
+        database.delete(OsmQuestTable.NAME, where, args)
+        database.delete(UndoOsmQuestTable.NAME, where, args)
+        database.delete(WayTrafficFlowTable.NAME, null, null)
+    }
+}
+
+val MIGRATION_11_12 = object : Migration(11, 12) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(OsmQuestSplitWayTable.CREATE)
+        // slightly different structure for undo osm quest table. Isn't worth converting
+        database.execSQL("DROP TABLE ${UndoOsmQuestTable.NAME}")
+        database.execSQL("DROP VIEW ${UndoOsmQuestTable.NAME_MERGED_VIEW}")
+        database.execSQL(UndoOsmQuestTable.CREATE)
+        database.execSQL(UndoOsmQuestTable.MERGED_VIEW_CREATE)
+    }
+}
+
+val MIGRATION_12_13 = object : Migration(12, 13) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(UserAchievementsTable.CREATE)
+        database.execSQL(UserLinksTable.CREATE)
+        database.execSQL(NewUserAchievementsTable.CREATE)
+    }
+}
+
+val MIGRATION_13_14 = object : Migration(13, 14) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(CountryStatisticsTable.CREATE)
+    }
+}
+
+val MIGRATION_14_15 = object : Migration(14, 15) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("""
+            ALTER TABLE ${OsmQuestSplitWayTable.NAME}
+            ADD COLUMN ${OsmQuestSplitWayTable.Columns.QUEST_TYPES_ON_WAY} text;
+            """.trimIndent()
+        )
+    }
+}
+
+val MIGRATION_15_16 = object : Migration(15, 16) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        /* there was an indication that relations downloaded and serialized with v22.0-beta1 and
+           v22.0 might have corrupt relation members. So to be on the safe side, we better clean
+           ALL the relations currently in the store. See #2014
+         */
+        database.execSQL("""
+            DELETE FROM ${OsmQuestTable.NAME}
+            WHERE ${OsmQuestTable.Columns.ELEMENT_TYPE} = "${Element.Type.RELATION.name}"
+        """.trimIndent())
+        database.execSQL("""
+            DELETE FROM ${UndoOsmQuestTable.NAME}
+            WHERE ${UndoOsmQuestTable.Columns.ELEMENT_TYPE} = "${Element.Type.RELATION.name}"
+        """.trimIndent())
+        database.execSQL("""
+            DELETE FROM ${RelationTable.NAME}
+        """.trimIndent())
+    }
+}
+
+val MIGRATION_16_17 = object : Migration(16, 17) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // An empty migration tells Room to keep the existing data.
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/data/model/ElementGeometry.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/model/ElementGeometry.kt
@@ -1,0 +1,30 @@
+package de.westnordost.streetcomplete.data.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import androidx.room.Entity
+import de.westnordost.streetcomplete.data.osm.elementgeometry.ElementGeometryTable
+
+@Entity(
+    tableName = ElementGeometryTable.NAME,
+    primaryKeys = [
+        ElementGeometryTable.Columns.ELEMENT_TYPE,
+        ElementGeometryTable.Columns.ELEMENT_ID
+    ]
+)
+data class ElementGeometry(
+    @ColumnInfo(name = ElementGeometryTable.Columns.ELEMENT_TYPE)
+    val elementType: String,
+
+    @ColumnInfo(name = ElementGeometryTable.Columns.ELEMENT_ID)
+    val elementId: Int,
+
+    @ColumnInfo(name = ElementGeometryTable.Columns.GEOMETRY_POLYGONS)
+    val polygons: List<List<LatLon>>,
+
+    @ColumnInfo(name = ElementGeometryTable.Columns.GEOMETRY_POLYLINES)
+    val polylines: List<List<LatLon>>,
+
+    @Embedded
+    var latLon: LatLon
+)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/model/LatLon.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/model/LatLon.kt
@@ -1,0 +1,11 @@
+package de.westnordost.streetcomplete.data.model
+
+import androidx.room.ColumnInfo
+import de.westnordost.streetcomplete.data.osm.elementgeometry.ElementGeometryTable
+
+data class LatLon(
+    @ColumnInfo(name = ElementGeometryTable.Columns.LATITUDE)
+    var latitude: Double,
+    @ColumnInfo(name = ElementGeometryTable.Columns.LONGITUDE)
+    var longitude: Double
+)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/model/Node.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/model/Node.kt
@@ -1,0 +1,15 @@
+package de.westnordost.streetcomplete.data.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import de.westnordost.streetcomplete.data.osm.mapdata.NodeTable
+
+@Entity(tableName = NodeTable.NAME)
+data class Node(
+    @PrimaryKey
+    val id: Int,
+    var version: Int,
+    var latitude: Double,
+    var longitude: Double,
+    val tags: Map<String, String>?
+)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/model/OsmQuest.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/model/OsmQuest.kt
@@ -1,0 +1,50 @@
+package de.westnordost.streetcomplete.data.model
+
+import androidx.room.*
+import de.westnordost.streetcomplete.data.osm.changes.StringMapChanges
+import de.westnordost.streetcomplete.data.osm.elementgeometry.ElementGeometryTable
+import de.westnordost.streetcomplete.data.osm.osmquest.OsmQuestTable
+import de.westnordost.streetcomplete.data.quest.QuestStatus
+import java.util.*
+
+@Entity(
+    foreignKeys = [
+        ForeignKey(
+            entity = ElementGeometry::class,
+            parentColumns = [ElementGeometryTable.Columns.ELEMENT_ID, ElementGeometryTable.Columns.ELEMENT_TYPE],
+            childColumns = [OsmQuestTable.Columns.ELEMENT_ID, OsmQuestTable.Columns.ELEMENT_TYPE]
+        )
+    ],
+    indices = [
+        Index(value = [
+            OsmQuestTable.Columns.QUEST_TYPE, OsmQuestTable.Columns.ELEMENT_ID, OsmQuestTable.Columns.ELEMENT_TYPE
+        ], unique = true)
+    ],
+    tableName = OsmQuestTable.NAME
+)
+data class OsmQuest(
+    @PrimaryKey
+    @ColumnInfo(name = OsmQuestTable.Columns.QUEST_ID)
+    val id: Int,
+
+    @ColumnInfo(name = OsmQuestTable.Columns.QUEST_TYPE)
+    var type: String,
+
+    @ColumnInfo(name = OsmQuestTable.Columns.QUEST_STATUS)
+    var status: QuestStatus,
+
+    @ColumnInfo(name = OsmQuestTable.Columns.TAG_CHANGES)
+    var changes: StringMapChanges?,
+
+    @ColumnInfo(name = OsmQuestTable.Columns.CHANGES_SOURCE)
+    var changesSource: String?,
+
+    @ColumnInfo(name = OsmQuestTable.Columns.LAST_UPDATE)
+    var lastUpdate: Date,
+
+    @ColumnInfo(name = OsmQuestTable.Columns.ELEMENT_ID)
+    var elementId: Int,
+
+    @ColumnInfo(name = OsmQuestTable.Columns.ELEMENT_TYPE)
+    var elementType: String
+)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/model/UndoOsmQuest.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/model/UndoOsmQuest.kt
@@ -1,0 +1,43 @@
+package de.westnordost.streetcomplete.data.model
+
+import androidx.room.*
+import de.westnordost.streetcomplete.data.osm.changes.StringMapChanges
+import de.westnordost.streetcomplete.data.osm.elementgeometry.ElementGeometryTable
+import de.westnordost.streetcomplete.data.osm.osmquest.undo.UndoOsmQuestTable
+
+@Entity(
+    foreignKeys = [
+        ForeignKey(
+            entity = ElementGeometry::class,
+            parentColumns = [ElementGeometryTable.Columns.ELEMENT_ID, ElementGeometryTable.Columns.ELEMENT_TYPE],
+            childColumns = [UndoOsmQuestTable.Columns.ELEMENT_ID, UndoOsmQuestTable.Columns.ELEMENT_TYPE]
+        )
+    ],
+    indices = [
+        Index(value = [
+            UndoOsmQuestTable.Columns.QUEST_TYPE, UndoOsmQuestTable.Columns.ELEMENT_ID,
+            UndoOsmQuestTable.Columns.ELEMENT_TYPE
+        ], unique = true)
+    ],
+    tableName = UndoOsmQuestTable.NAME
+)
+data class UndoOsmQuest(
+    @PrimaryKey
+    @ColumnInfo(name = UndoOsmQuestTable.Columns.QUEST_ID)
+    val id: Int,
+
+    @ColumnInfo(name = UndoOsmQuestTable.Columns.QUEST_TYPE)
+    var type: String,
+
+    @ColumnInfo(name = UndoOsmQuestTable.Columns.TAG_CHANGES)
+    var changes: StringMapChanges,
+
+    @ColumnInfo(name = UndoOsmQuestTable.Columns.CHANGES_SOURCE)
+    var changesSource: String,
+
+    @ColumnInfo(name = UndoOsmQuestTable.Columns.ELEMENT_ID)
+    var elementId: Int,
+
+    @ColumnInfo(name = UndoOsmQuestTable.Columns.ELEMENT_TYPE)
+    var elementType: String
+)

--- a/app/src/main/java/de/westnordost/streetcomplete/data/model/Way.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/model/Way.kt
@@ -1,0 +1,17 @@
+package de.westnordost.streetcomplete.data.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import de.westnordost.streetcomplete.data.osm.mapdata.WayTable
+
+@Entity(tableName = WayTable.NAME)
+data class Way(
+    @PrimaryKey
+    val id: Int,
+    var version: Int,
+    val tags: Map<String, String>?,
+
+    @ColumnInfo(name = WayTable.Columns.NODE_IDS)
+    val nodeIds: List<Long>
+)

--- a/app/src/main/java/de/westnordost/streetcomplete/ktx/SupportSQLiteDatabase.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ktx/SupportSQLiteDatabase.kt
@@ -1,0 +1,32 @@
+package de.westnordost.streetcomplete.ktx
+
+import android.database.Cursor
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteQueryBuilder
+
+fun <R> SupportSQLiteDatabase.queryOne(
+    table: String,
+    columns: Array<String>? = null,
+    selection: String? = null,
+    selectionArgs: Array<String>? = null,
+    orderBy: String? = null,
+    transform: (Cursor) -> R?
+): R? {
+    val query = SupportSQLiteQueryBuilder.builder(table)
+        .columns(columns)
+        .selection(selection, selectionArgs)
+        .orderBy(orderBy)
+        .limit("1")
+        .create()
+    return query(query).use { cursor ->
+        if (cursor.moveToFirst()) transform(cursor) else null
+    }
+}
+
+fun SupportSQLiteDatabase.hasColumn(tableName: String, columnName: String): Boolean {
+    return queryOne(
+        "pragma_table_info('$tableName')",
+        arrayOf("name"),
+        "name = ?",
+        arrayOf(columnName)) { it.getString(0) } != null
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/util/KryoSerializer.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/KryoSerializer.java
@@ -4,6 +4,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
+import org.jetbrains.annotations.NotNull;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import java.util.ArrayList;
@@ -12,26 +13,26 @@ import java.util.HashMap;
 
 import javax.inject.Singleton;
 
-import de.westnordost.osmapi.map.data.Fixed1E7LatLon;
-import de.westnordost.streetcomplete.data.osm.splitway.SplitAtLinePosition;
-import de.westnordost.streetcomplete.data.osm.splitway.SplitAtPoint;
-import de.westnordost.streetcomplete.data.osm.changes.StringMapChanges;
-import de.westnordost.streetcomplete.data.osm.changes.StringMapEntryAdd;
-import de.westnordost.streetcomplete.data.osm.changes.StringMapEntryDelete;
-import de.westnordost.streetcomplete.data.osm.changes.StringMapEntryModify;
-import de.westnordost.streetcomplete.quests.opening_hours.adapter.OffDaysRow;
-import de.westnordost.streetcomplete.quests.opening_hours.adapter.OpeningMonthsRow;
-import de.westnordost.streetcomplete.quests.opening_hours.adapter.OpeningWeekdaysRow;
-import de.westnordost.streetcomplete.quests.opening_hours.model.CircularSection;
 import de.westnordost.osmapi.map.data.Element;
+import de.westnordost.osmapi.map.data.Fixed1E7LatLon;
 import de.westnordost.osmapi.map.data.OsmLatLon;
 import de.westnordost.osmapi.map.data.OsmRelationMember;
 import de.westnordost.osmapi.notes.NoteComment;
 import de.westnordost.osmapi.user.User;
+import de.westnordost.streetcomplete.data.osm.changes.StringMapChanges;
+import de.westnordost.streetcomplete.data.osm.changes.StringMapEntryAdd;
+import de.westnordost.streetcomplete.data.osm.changes.StringMapEntryDelete;
+import de.westnordost.streetcomplete.data.osm.changes.StringMapEntryModify;
+import de.westnordost.streetcomplete.data.osm.splitway.SplitAtLinePosition;
+import de.westnordost.streetcomplete.data.osm.splitway.SplitAtPoint;
+import de.westnordost.streetcomplete.quests.LocalizedName;
+import de.westnordost.streetcomplete.quests.opening_hours.adapter.OffDaysRow;
+import de.westnordost.streetcomplete.quests.opening_hours.adapter.OpeningMonthsRow;
+import de.westnordost.streetcomplete.quests.opening_hours.adapter.OpeningWeekdaysRow;
+import de.westnordost.streetcomplete.quests.opening_hours.model.CircularSection;
 import de.westnordost.streetcomplete.quests.opening_hours.model.Months;
 import de.westnordost.streetcomplete.quests.opening_hours.model.TimeRange;
 import de.westnordost.streetcomplete.quests.opening_hours.model.Weekdays;
-import de.westnordost.streetcomplete.quests.LocalizedName;
 import de.westnordost.streetcomplete.quests.postbox_collection_times.WeekdaysTimesRow;
 
 @Singleton
@@ -89,6 +90,7 @@ public class KryoSerializer implements Serializer
 		}
 	};
 
+	@NotNull
 	@Override public byte[] toBytes(Object object)
 	{
 		Output output = new Output(1024,-1);

--- a/app/src/main/java/de/westnordost/streetcomplete/util/Serializer.java
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/Serializer.java
@@ -1,7 +1,11 @@
 package de.westnordost.streetcomplete.util;
 
+import androidx.annotation.NonNull;
+
 public interface Serializer
 {
+	@NonNull
 	byte[] toBytes(Object object);
+
 	<T> T toObject(byte[] bytes, Class<T> type);
 }


### PR DESCRIPTION
Add a `RoomDatabase` implementation, migrations and entities, and switch to `SupportSQLiteOpenHelper`. This PR is limited to those changes to keep it as simple as possible, with the intent being to fully switch to Room over multiple PRs: https://medium.com/androiddevelopers/incrementally-migrate-from-sqlite-to-room-66c2f655b377.