### PR TITLE
clarify building=bridge - that it should not be used for where man_made=bridge should be used

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingTypeItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/building_type/BuildingTypeItem.kt
@@ -62,7 +62,7 @@ fun BuildingType.asItem(): Item<BuildingType?> = when(this) {
     BOATHOUSE -> Item(this, R.drawable.ic_building_boathouse, R.string.quest_buildingType_boathouse)
     ALLOTMENT_HOUSE -> Item(this, R.drawable.ic_building_allotment_house, R.string.quest_buildingType_allotment_house)
     ROOF -> Item(this, R.drawable.ic_building_roof, R.string.quest_buildingType_roof)
-    BRIDGE -> Item(this, R.drawable.ic_building_bridge, R.string.quest_buildingType_bridge)
+    BRIDGE -> Item(this, R.drawable.ic_building_bridge, R.string.quest_buildingType_bridge, R.string.quest_buildingType_bridge_description)
     TOILETS -> Item(this, R.drawable.ic_building_toilets, R.string.quest_buildingType_toilets)
     SERVICE -> Item(this, R.drawable.ic_building_service, R.string.quest_buildingType_service, R.string.quest_buildingType_service_description)
     HANGAR -> Item(this, R.drawable.ic_building_hangar, R.string.quest_buildingType_hangar, R.string.quest_buildingType_hangar_description)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -687,6 +687,7 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_buildingType_hut_description">small, simple dwelling or shelter</string>
     <string name="quest_buildingType_roof">Roof</string>
     <string name="quest_buildingType_bridge">Bridge between buildings (skyway)</string>
+    <string name="quest_buildingType_bridge_description">Only for bridges that are also a building or building part.</string>
     <string name="quest_buildingType_service">Service building</string>
     <string name="quest_buildingType_service_description">building with machinery like pumps or transformers</string>
     <string name="quest_buildingType_hangar">Hangar</string>


### PR DESCRIPTION
`building=*` was very often used for bridge outlines. Introduction of `man_made=bridge` reduced this, but there are still places where it happens.

This extra info tries to direct user to leaving note in case where `bridge=yes` area that should be `man_made=bridge` is encountered by SC mapper

![screen](https://user-images.githubusercontent.com/899988/136660700-34395391-eb06-43cc-8b92-91302aeb3b8c.png)
