### PR TITLE
Don't ask for crossing type when the highway is private

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingType.kt
@@ -1,15 +1,25 @@
 package de.westnordost.streetcomplete.quests.crossing_type
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.meta.updateCheckDateForKey
 import de.westnordost.streetcomplete.data.meta.updateWithCheckDate
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.edits.update_tags.StringMapChangesBuilder
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.PEDESTRIAN
 
-class AddCrossingType : OsmFilterQuestType<CrossingType>() {
+class AddCrossingType : OsmElementQuestType<CrossingType> {
 
-    override val elementFilter = """
+    /*
+       Always ask for deprecated/meaningless values (island, unknown, yes)
+
+       Only ask again for crossing types that are known to this quest so to be conservative with
+       existing data
+     */
+    private val crossingFilter by lazy { """
         nodes with highway = crossing
           and foot != no
           and (
@@ -20,13 +30,12 @@ class AddCrossingType : OsmFilterQuestType<CrossingType>() {
               and crossing older today -8 years
             )
           )
-    """
-    /*
-       Always ask for deprecated/meaningless values (island, unknown, yes)
+    """.toElementFilterExpression()}
 
-       Only ask again for crossing types that are known to this quest so to be conservative with
-       existing data
-     */
+    private val excludedWaysFilter by lazy { """
+        ways with
+          highway and access ~ private|no
+    """.toElementFilterExpression()}
 
     override val commitMessage = "Add crossing type"
     override val wikiLink = "Key:crossing"
@@ -35,6 +44,19 @@ class AddCrossingType : OsmFilterQuestType<CrossingType>() {
     override val questTypeAchievements = listOf(PEDESTRIAN)
 
     override fun getTitle(tags: Map<String, String>) = R.string.quest_crossing_type_title
+
+    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
+        val excludedWayNodeIds = mutableSetOf<Long>()
+        mapData.ways
+            .filter { excludedWaysFilter.matches(it) }
+            .flatMapTo(excludedWayNodeIds) { it.nodeIds }
+
+        return mapData.nodes
+            .filter { crossingFilter.matches(it) && it.id !in excludedWayNodeIds }
+    }
+
+    override fun isApplicableTo(element: Element): Boolean? =
+        if (!crossingFilter.matches(element)) false else null
 
     override fun createForm() = AddCrossingTypeForm()
 


### PR DESCRIPTION
If a highway=crossing is on a road with access=private or access=no, we should not be encouraging the mapper to ascertain what sort of crossing it is.