### PR TITLE
Don't ask for internet access on things that are marked as private

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/internet_access/AddInternetAccess.kt
@@ -14,6 +14,7 @@ class AddInternetAccess : OsmFilterQuestType<InternetAccess>() {
           amenity ~ library|community_centre|youth_centre
           or tourism ~ hotel|guest_house|motel|hostel|alpine_hut|apartment|resort|camp_site|caravan_site|chalet
         )
+        and access !~ no|private
         and name
         and (
           !internet_access


### PR DESCRIPTION
If a thing is marked as private, we shouldn't be asking mappers to go and work out if it provides internet access or not.

In my case, it is to stop a private school library from asking me this question.