### PR TITLE
Fix Message Board Type string reference

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/board_type/AddBoardTypeForm.kt
@@ -20,7 +20,7 @@ class AddBoardTypeForm : AListQuestAnswerFragment<BoardType>() {
         TextItem(WILDLIFE, R.string.quest_board_type_wildlife),
         TextItem(NATURE, R.string.quest_board_type_nature),
         TextItem(PUBLIC_TRANSPORT, R.string.quest_board_type_public_transport),
-        TextItem(SPORT, R.string.quest_board_type_public_transport),
+        TextItem(SPORT, R.string.quest_board_type_sport),
         TextItem(NOTICE, R.string.quest_board_type_notice_board),
     )
 


### PR DESCRIPTION
In [this Telegram message](https://t.me/OSM_de/65246) Wieland Breitfeld noted, that the Message Board Type showed "ÖPNV" (public transport) twice.

This PR fixes the duplicate string reference.