### PR TITLE
remove crossing from crossing type answers

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_type/AddCrossingTypeForm.kt
@@ -8,9 +8,9 @@ import de.westnordost.streetcomplete.view.image_select.Item
 class AddCrossingTypeForm : AImageListQuestAnswerFragment<CrossingType, CrossingType>() {
 
     override val items = listOf(
-        Item(TRAFFIC_SIGNALS, R.drawable.crossing_type_signals, R.string.quest_crossing_type_signals_controlled2),
-        Item(MARKED, R.drawable.crossing_type_zebra, R.string.quest_crossing_type_marked2),
-        Item(UNMARKED, R.drawable.crossing_type_unmarked, R.string.quest_crossing_type_unmarked2)
+        Item(TRAFFIC_SIGNALS, R.drawable.crossing_type_signals, R.string.quest_crossing_type_signals_controlled),
+        Item(MARKED, R.drawable.crossing_type_zebra, R.string.quest_crossing_type_marked),
+        Item(UNMARKED, R.drawable.crossing_type_unmarked, R.string.quest_crossing_type_unmarked)
     )
 
     override val itemsPerRow = 3

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,9 +371,9 @@ Otherwise, you can download another keyboard in the app store. Popular keyboards
     <string name="quest_maxspeed_answer_living_street_confirmation_title">So, there is a sign like this?</string>
     <string name="quest_crossing_title">Are there curbs where this way meets this road here? What kind?</string>
     <string name="quest_crossing_type_title">What kind of crossing is this?</string>
-    <string name="quest_crossing_type_signals_controlled2">Controlled by traffic lights</string>
-    <string name="quest_crossing_type_marked2">Marked</string>
-    <string name="quest_crossing_type_unmarked2">Without road markings</string>
+    <string name="quest_crossing_type_signals_controlled">Controlled by traffic lights</string>
+    <string name="quest_crossing_type_marked">Marked</string>
+    <string name="quest_crossing_type_unmarked">Without road markings</string>
     <string name="action_undo">Undo</string>
     <string name="undo_last">Undo last edit</string>
     <string name="show_edit_history">Show edit history</string>


### PR DESCRIPTION
simplify and reduce answer length
deemphasize 'crossing' part
thanks to smichel12 for idea - https://github.com/streetcomplete/StreetComplete/discussions/3341#discussioncomment-1439286
fixes small part of #3341