### PR TITLE
Allow to hide zoom buttons

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/Prefs.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/Prefs.kt
@@ -11,6 +11,7 @@ object Prefs {
     const val SHOW_NOTES_NOT_PHRASED_AS_QUESTIONS = "display.nonQuestionNotes"
     const val AUTOSYNC = "autosync"
     const val KEEP_SCREEN_ON = "display.keepScreenOn"
+    const val SHOW_ZOOM_BUTTONS = "display.showZoomButtons"
     const val UNGLUE_HINT_TIMES_SHOWN = "unglueHint.shown"
     const val THEME_SELECT = "theme.select"
     const val THEME_BACKGROUND = "theme.background_type"

--- a/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
@@ -26,6 +26,7 @@ import androidx.core.graphics.toPointF
 import androidx.core.graphics.toRectF
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
 import androidx.fragment.app.commit
@@ -165,6 +166,13 @@ class MainFragment : Fragment(R.layout.fragment_main),
         binding.zoomOutButton.setOnClickListener { onClickZoomOut() }
 
         updateMapQuestOffsets()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val zoomButtonsVisible = prefs.getBoolean(Prefs.SHOW_ZOOM_BUTTONS, true)
+        binding.zoomInButton.isVisible = zoomButtonsVisible
+        binding.zoomOutButton.isVisible = zoomButtonsVisible
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="pref_tilecache_size_summary">"%d MB"</string>
     <string name="pref_tilecache_size_message">"Space in megabytes reserved on external storage to cache map tiles"</string>
     <string name="pref_title_show_notes_not_phrased_as_questions">"Show all notes"</string>
+    <string name="pref_title_show_zoom_buttons">Show zoom buttons</string>
     <string name="pref_summaryOn_show_notes_not_phrased_as_questions">"Also showing notes not phrased as questions"</string>
     <string name="pref_summaryOff_show_notes_not_phrased_as_questions">"Ignoring notes not phrased as questions"</string>
     <string name="pref_title_map_cache">"Map cache size"</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -61,6 +61,13 @@
             android:persistent="true"
             />
 
+        <SwitchPreference
+            android:key="display.showZoomButtons"
+            android:title="@string/pref_title_show_zoom_buttons"
+            android:defaultValue="true"
+            android:persistent="true"
+            />
+
     <!--
         <ListPreference
             android:key="theme.background_type"


### PR DESCRIPTION
## Change description
I don't use zoom in/out buttons, I use pinch gestures instead.
Therefore I think there should be an option to hide them.

Change has been inspired by [Organic Maps](https://github.com/organicmaps/organicmaps) which has the same option available.
I could add their [translations](https://github.com/organicmaps/organicmaps/search?l=XML&q=pref_zoom_title) as they use Apache 2.0 license, right?

## Screenshots:
Settings             |  Zoom buttons displayed | Zoom buttons hidden
:-------------------------:|:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2798728/137556015-f560808c-6c9e-49fa-ab1f-2625dadc40da.png)  | ![](https://user-images.githubusercontent.com/2798728/137556053-98f081f1-8b61-4c57-8d08-fa6d0f94add5.png) | ![](https://user-images.githubusercontent.com/2798728/137556058-2fe77717-2bbb-460a-a9d8-fc0aa9bb73a3.png)