### PR TITLE
stop asking crossing detail for unmarked crossings

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/crossing_island/AddCrossingIsland.kt
@@ -18,6 +18,7 @@ class AddCrossingIsland : OsmElementQuestType<Boolean> {
           highway = crossing
           and foot != no
           and crossing
+          and crossing != unmarked
           and crossing != island
           and !crossing:island
     """.toElementFilterExpression()}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tactile_paving/AddTactilePavingCrosswalk.kt
@@ -16,7 +16,7 @@ class AddTactilePavingCrosswalk : OsmElementQuestType<Boolean> {
         nodes with
           (
             highway = traffic_signals and crossing = traffic_signals and foot != no
-            or highway = crossing and foot != no
+            or highway = crossing and foot != no and crossing and crossing != unmarked
           )
           and (
             !tactile_paving


### PR DESCRIPTION
this type of object is considered as crossing in OSM tagging, but not by many regular people
as result it can be a very confusing quest, see #3341

alternative solutions:
- consider confusion as acceptable and require people to be aware about OSM classification (contrary to SC purpose and design)
- explain somehow that it may be not exactly crossing as regularly understood
- reword questions somehow to reduce confusion

Main negative effect here is that unmarked crossings may have a pedestrian island and tactile_paving data is useful also on unmarked crossings