### PR TITLE
Use LocationManagerCompat.getCurrentLocation().

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestAutoSyncer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestAutoSyncer.kt
@@ -50,7 +50,7 @@ import javax.inject.Singleton
 
     // new location is known -> check if downloading makes sense now
     private val locationManager = FineLocationManager(context) { location ->
-        if (location != null && location.accuracy <= 300) {
+        if (location.accuracy <= 300) {
             pos = location.toLatLon()
             triggerAutoDownload()
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/LocationAwareMapFragment.kt
@@ -183,15 +183,13 @@ open class LocationAwareMapFragment : MapFragment() {
         if (shouldCenterCurrentPosition()) centerCurrentPosition()
     }
 
-    private fun onLocationChanged(location: Location?) {
-        if (location != null) {
-            displayedLocation = location
-            locationMapComponent?.location = location
-            addTrackLocation(location)
-            compass.setLocation(location)
-            centerCurrentPositionIfFollowing()
-            listener?.onDisplayedLocationDidChange()
-        }
+    private fun onLocationChanged(location: Location) {
+        displayedLocation = location
+        locationMapComponent?.location = location
+        addTrackLocation(location)
+        compass.setLocation(location)
+        centerCurrentPositionIfFollowing()
+        listener?.onDisplayedLocationDidChange()
     }
 
     private fun addTrackLocation(location: Location) {

--- a/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/map/MainFragment.kt
@@ -18,7 +18,6 @@ import androidx.annotation.AnyThread
 import androidx.annotation.DrawableRes
 import androidx.annotation.UiThread
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.content.getSystemService
 import androidx.core.graphics.Insets
 import androidx.core.graphics.minus
 import androidx.core.graphics.toPointF
@@ -572,11 +571,9 @@ class MainFragment : Fragment(R.layout.fragment_main),
         }
     }
 
-    private fun onLocationChanged(location: Location?) {
-        if (location != null) {
-            binding.gpsTrackingButton.state = LocationState.UPDATING
-            updateLocationPointerPin()
-        }
+    private fun onLocationChanged(location: Location) {
+        binding.gpsTrackingButton.state = LocationState.UPDATING
+        updateLocationPointerPin()
     }
 
     //endregion


### PR DESCRIPTION
[`LocationManager#requestSingleUpdate`](https://developer.android.com/reference/android/location/LocationManager#requestSingleUpdate(java.lang.String,%20android.location.LocationListener,%20android.os.Looper)) has been deprecated in API level 30 in favor of [`LocationManager#getCurrentLocation`](https://developer.android.com/reference/android/location/LocationManager#getCurrentLocation(java.lang.String,%20android.os.CancellationSignal,%20java.util.concurrent.Executor,%20java.util.function.Consumer%3Candroid.location.Location%3E)) as the latter does not carry a risk of extreme battery drain.