### PR TITLE
AddCycleway stopped by parallel construction

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -326,8 +326,9 @@ class AddCycleway(private val countryInfos: CountryInfos) : OsmElementQuestType<
         """.toElementFilterExpression() }
 
         private val maybeSeparatelyMappedCyclewaysFilter by lazy { """
-            ways with highway ~ path|footway|cycleway
+            ways with highway ~ path|footway|cycleway|construction
         """.toElementFilterExpression() }
+        // highway=construction included, as situation often changes during and after construction
 
         private val notIn30ZoneOrLess = MAXSPEED_TYPE_KEYS.joinToString(" or ") {
             """$it and $it !~ ".*zone:?([1-9]|[1-2][0-9]|30)""""


### PR DESCRIPTION
highway=construction now stops the quest
even if cycleway under construction is not mapped then waiting until nearby construction ends is still preferable
even if it is road being constructed not cycleway it is better to wait
triggered by #3434

Note: edited online, will test once back home