### PR TITLE
Fix crash on opening building levels quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/LastPickedValuesStore.kt
@@ -25,7 +25,8 @@ class LastPickedValuesStore<T> @Inject constructor(private val prefs: SharedPref
         add(key, listOf(value), max, allowDuplicates)
     }
 
-    fun get(key: String): Sequence<String> = prefs.getString(getKey(key), "")!!.splitToSequence(",")
+    fun get(key: String): Sequence<String> =
+        prefs.getString(getKey(key), null)?.splitToSequence(",") ?: sequenceOf()
 
     private fun getKey(key: String) = Prefs.LAST_PICKED_PREFIX + key
 }


### PR DESCRIPTION
It happened when there was no history, because "".splitToSequence(",") produces sequenceOf(""), not an empty sequence, and the building levels parsing code doesn't expect an empty string.

Fixes #3446