### PR TITLE
Show reference number in AddFireHydrantPosition quest title if exists

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/fire_hydrant_position/AddFireHydrantPosition.kt
@@ -7,6 +7,8 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.Tags
 import de.westnordost.streetcomplete.data.user.achievements.QuestTypeAchievement.LIFESAVER
+import de.westnordost.streetcomplete.ktx.arrayOfNotNull
+import de.westnordost.streetcomplete.ktx.containsAnyKey
 
 class AddFireHydrantPosition : OsmFilterQuestType<FireHydrantPosition>() {
 
@@ -22,7 +24,16 @@ class AddFireHydrantPosition : OsmFilterQuestType<FireHydrantPosition>() {
 
     override val questTypeAchievements = listOf(LIFESAVER)
 
-    override fun getTitle(tags: Map<String, String>) = R.string.quest_fireHydrant_position_title
+    override fun getTitleArgs(tags: Map<String, String>, featureName: Lazy<String?>): Array<String> =
+        arrayOfNotNull(tags["ref"])
+
+    override fun getTitle(tags: Map<String, String>): Int {
+        val hasRef = tags.containsAnyKey("ref")
+        return when {
+            hasRef -> R.string.quest_fireHydrant_position_ref_title
+            else   -> R.string.quest_fireHydrant_position_title
+        }
+    }
 
     override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
         getMapData().filter("nodes with emergency = fire_hydrant")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1140,6 +1140,7 @@ If you are overwhelmed by the number of quests, you can always fine-tune which q
     <string name="quest_presets_delete_message">"Delete preset “%s”? The quest selection and order for it will be irrevocably lost."</string>
     <string name="quest_picnicTableCover_title">Is this picnic table covered (protected from rain)?</string>
     <string name="quest_fireHydrant_position_title">Where is this fire hydrant located?</string>
+    <string name="quest_fireHydrant_position_ref_title">Where is this fire hydrant located? (reference number: %s)</string>
     <string name="quest_fireHydrant_position_green">In grass or dirt</string>
     <string name="quest_fireHydrant_position_lane">On the roadway</string>
     <string name="quest_fireHydrant_position_sidewalk">On the sidewalk</string>


### PR DESCRIPTION
Basically identical to #3608.

Also a useful feature for tagging when multiply hydrants are close together.