### PR TITLE
Clean up quest selection row layout

### DIFF
--- a/app/src/main/res/layout/row_quest_selection.xml
+++ b/app/src/main/res/layout/row_quest_selection.xml
@@ -4,78 +4,60 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?android:attr/colorBackground"
     android:paddingTop="8dp"
-    android:paddingBottom="8dp"
-    tools:ignore="RtlSymmetry">
-
-    <ImageView
-        android:id="@+id/questIcon"
-        android:layout_width="@dimen/table_icon_size"
-        android:layout_height="@dimen/table_icon_size"
-        android:layout_alignParentStart="true"
-        android:layout_centerVertical="true"
-        android:layout_marginStart="24dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/dragHandle"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:src="@drawable/ic_quest_street" />
+    android:paddingBottom="8dp">
 
     <ImageView
         android:id="@+id/dragHandle"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
-        android:paddingEnd="24dp"
         android:src="@drawable/ic_drag_vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <LinearLayout
-        android:id="@+id/linearLayout"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/visibilityCheckBoxContainer"
-        app:layout_constraintStart_toEndOf="@+id/questIcon"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/questTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="@android:style/TextAppearance.Theme.Dialog"
-            tools:text="@string/quest_lanes_title" />
-
-        <TextView
-            android:id="@+id/disabledText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:background="@drawable/background_quest_disabled_notice"
-            android:textStyle="italic"
-            tools:text="@string/questList_disabled_in_country" />
-
-    </LinearLayout>
-
-    <FrameLayout
-        android:id="@+id/visibilityCheckBoxContainer"
+    <ImageView
+        android:id="@+id/questIcon"
         android:layout_width="@dimen/table_icon_size"
         android:layout_height="@dimen/table_icon_size"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/dragHandle"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/ic_quest_street" />
+
+    <TextView
+        android:layout_marginStart="16dp"
+        app:layout_constraintEnd_toStartOf="@+id/visibilityCheckBox"
+        app:layout_constraintStart_toEndOf="@+id/questIcon"
+        app:layout_constraintBottom_toTopOf="@id/disabledText"
+        app:layout_constraintTop_toTopOf="parent"
+        android:id="@+id/questTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="@android:style/TextAppearance.Theme.Dialog"
+        tools:text="@string/quest_lanes_title" />
+
+    <TextView
+        android:layout_marginStart="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/visibilityCheckBox"
+        app:layout_constraintStart_toEndOf="@+id/questIcon"
+        app:layout_constraintTop_toBottomOf="@id/questTitle"
+        app:layout_constraintHorizontal_bias="0"
+        android:id="@+id/disabledText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:background="@drawable/background_quest_disabled_notice"
+        android:textStyle="italic"
+        tools:text="@string/questList_disabled_in_country" />
+
+    <CheckBox
+        android:id="@+id/visibilityCheckBox"
+        android:layout_width="64dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <CheckBox
-            android:id="@+id/visibilityCheckBox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center" />
-
-    </FrameLayout>
-
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR removes unnecessary layout attributes and inner layouts from the `row_quest_selection.xml` layout. It also increases the touch target size of the check boxes to be 64dp wide and span the entire row height for all screen sizes to fix #5010. As can be seen from the below screenshot, the layout looks otherwise the same as before.
 
![Screenshot_20230617_131321](https://github.com/streetcomplete/StreetComplete/assets/6892794/fc254221-8eab-4b36-be98-9edc911eac72)
