### PR TITLE
test: fix range for 'too low' test case in CircularSectionTest

### DIFF
--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/osm/opening_hours/model/CircularSectionTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/osm/opening_hours/model/CircularSectionTest.kt
@@ -22,7 +22,7 @@ class CircularSectionTest {
     @Test fun intersect() {
         val cs = CircularSection(0, 10)
         val tooHigh = CircularSection(11, 12)
-        val tooLow = CircularSection(11, 12)
+        val tooLow = CircularSection(-2, -1)
         val touchesUpperEnd = CircularSection(10, 10)
         val touchesLowerEnd = CircularSection(-1, 0)
         val contains = CircularSection(-10, 20)


### PR DESCRIPTION
Fix tooLow test case for CircularSection() to [-2, -1], to test intersection logic correctly with range below the base range [0, 10].