### PR TITLE
osm: implement non-integer range handling in Level.Range.getSelectableLevels()

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/level/Level.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/level/Level.kt
@@ -15,6 +15,9 @@ sealed interface Level {
                 for (i in 0..range.toInt()) {
                     yield(start + i)
                 }
+            } else {
+                yield(start)
+                yield(end)
             }
         }
     }


### PR DESCRIPTION
Function was only yielding values for integer ranges. Added else case to yield start and end values for non-integer ranges, aligning implementation with existing code documentation.