### PR TITLE
Update RoadUtils and val usages

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/cycleway/CyclewayOverlay.kt
@@ -12,7 +12,11 @@ import de.westnordost.streetcomplete.data.overlays.OverlayColor
 import de.westnordost.streetcomplete.data.overlays.Overlay
 import de.westnordost.streetcomplete.data.overlays.OverlayStyle
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
+import de.westnordost.streetcomplete.osm.ALL_LINKS
 import de.westnordost.streetcomplete.osm.ALL_ROADS
+import de.westnordost.streetcomplete.osm.HIGHWAYS
+import de.westnordost.streetcomplete.osm.PATH_FOR_FOOT_AND_CYCLE
+import de.westnordost.streetcomplete.osm.TAGGING_NOT_ASSUMED
 import de.westnordost.streetcomplete.osm.bicycle_boulevard.BicycleBoulevard
 import de.westnordost.streetcomplete.osm.bicycle_boulevard.parseBicycleBoulevard
 import de.westnordost.streetcomplete.osm.cycleway.Cycleway
@@ -53,7 +57,7 @@ class CyclewayOverlay(
         // separately mapped ways
         mapData.filter("""
             ways with
-              highway ~ cycleway|path|footway
+              highway ~ ${PATH_FOR_FOOT_AND_CYCLE.joinToString("|")}
               and horse != designated
               and area != yes
         """).map { it to getSeparateCyclewayStyle(it) }
@@ -126,7 +130,7 @@ private fun getStreetStrokeStyle(tags: Map<String, String>): OverlayStyle.Stroke
 
 private val cyclewayTaggingNotExpectedFilter by lazy { """
     ways with
-      highway ~ track|living_street|pedestrian|service|motorway_link|motorway|busway
+      highway ~ ${TAGGING_NOT_ASSUMED.joinToString("|")}
       or motorroad = yes
       or expressway = yes
       or maxspeed <= 20
@@ -140,7 +144,7 @@ private val cyclewayTaggingNotExpectedFilter by lazy { """
 private val cyclewayTaggingInContraflowNotExpectedFilter by lazy { """
     ways with
       dual_carriageway = yes
-      or highway ~ primary_link|secondary_link|tertiary_link
+      or highway ~ ${(ALL_LINKS - HIGHWAYS).joinToString("|")}
       or junction ~ roundabout|circular
 """.toElementFilterExpression() }
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/sidewalk/SidewalkOverlay.kt
@@ -10,7 +10,9 @@ import de.westnordost.streetcomplete.data.overlays.OverlayColor
 import de.westnordost.streetcomplete.data.overlays.Overlay
 import de.westnordost.streetcomplete.data.overlays.OverlayStyle
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.osm.ALL_PATHS
 import de.westnordost.streetcomplete.osm.ALL_ROADS
+import de.westnordost.streetcomplete.osm.TAGGING_NOT_ASSUMED
 import de.westnordost.streetcomplete.osm.cycleway_separate.SeparateCycleway
 import de.westnordost.streetcomplete.osm.cycleway_separate.parseSeparateCycleway
 import de.westnordost.streetcomplete.osm.isPrivateOnFoot
@@ -42,7 +44,7 @@ class SidewalkOverlay : Overlay, AndroidOverlay {
         // possible to add sidewalks to them. At least in NL, cycleways with sidewalks actually exist
         mapData.filter("""
             ways with (
-              highway ~ footway|steps|path|bridleway|cycleway
+              highway ~ ${ALL_PATHS.joinToString("|")}
             ) and area != yes
         """).map { it to getFootwayStyle(it) }
 
@@ -100,7 +102,7 @@ private fun getStreetStrokeStyle(tags: Map<String, String>): OverlayStyle.Stroke
 
 private val sidewalkTaggingNotExpectedFilter by lazy { """
     ways with
-      highway ~ track|living_street|pedestrian|service|motorway_link|motorway|busway
+      highway ~ ${TAGGING_NOT_ASSUMED.joinToString("|")}
       or motorroad = yes
       or expressway = yes
       or maxspeed <= 10

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/overlays/street_parking/StreetParkingOverlay.kt
@@ -12,6 +12,11 @@ import de.westnordost.streetcomplete.data.overlays.Overlay
 import de.westnordost.streetcomplete.data.overlays.OverlayStyle
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
 import de.westnordost.streetcomplete.osm.ALL_ROADS
+import de.westnordost.streetcomplete.osm.LOCAL_ACCESS_ROADS
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.PEDESTRIAN_ONLY_ROADS
+import de.westnordost.streetcomplete.osm.TRUNKS
+import de.westnordost.streetcomplete.osm.UNCLASSIFIED_ROADS
 import de.westnordost.streetcomplete.osm.isPrivateOnFoot
 import de.westnordost.streetcomplete.osm.maxspeed.MAX_SPEED_TYPE_KEYS
 import de.westnordost.streetcomplete.osm.street_parking.ParkingPosition
@@ -40,7 +45,7 @@ class StreetParkingOverlay : Overlay, AndroidOverlay {
     override fun getStyledElements(mapData: MapDataWithGeometry): Sequence<Pair<Element, OverlayStyle>> =
         // roads
         mapData.filter("""
-            ways with highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|pedestrian|service
+            ways with highway ~ ${(TRUNKS + MAJOR_ROADS + LOCAL_ACCESS_ROADS + PEDESTRIAN_ONLY_ROADS + UNCLASSIFIED_ROADS + setOf("service")).joinToString("|")}
             and area != yes
         """).map { it to getStreetParkingStyle(it) } +
         // separate parking

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/building_entrance/AddEntrance.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/building_entrance/AddEntrance.kt
@@ -12,6 +12,8 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.osm.ALL_PATHS
+import de.westnordost.streetcomplete.osm.PATH_FOR_EQUESTRIANS
 import de.westnordost.streetcomplete.osm.Tags
 
 class AddEntrance : OsmElementQuestType<EntranceAnswer>, AndroidQuest {
@@ -30,7 +32,7 @@ class AddEntrance : OsmElementQuestType<EntranceAnswer>, AndroidQuest {
 
     private val incomingWaysFilter by lazy { """
         ways with
-          highway ~ path|footway|steps|cycleway and area != yes and access !~ private|no
+          highway ~ ${(ALL_PATHS - PATH_FOR_EQUESTRIANS).joinToString("|")} and area != yes and access !~ private|no
     """.toElementFilterExpression() }
 
     private val excludedWaysFilter by lazy { """

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/crossing/AddCrossing.kt
@@ -9,6 +9,9 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.osm.TRUNKS
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.PUBLIC_AND_UNCLASSIFIED
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.findNodesAtCrossingsOf
 import de.westnordost.streetcomplete.osm.isCrossing
@@ -18,7 +21,7 @@ class AddCrossing : OsmElementQuestType<CrossingAnswer>, AndroidQuest {
 
     private val roadsFilter by lazy { """
         ways with
-          highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|busway
+          highway ~ ${(TRUNKS + MAJOR_ROADS + PUBLIC_AND_UNCLASSIFIED + setOf("residential")).joinToString("|")}
           and area != yes
           and (access !~ private|no or (foot and foot !~ private|no))
     """.toElementFilterExpression() }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/crossing_kerb_height/AddCrossingKerbHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/crossing_kerb_height/AddCrossingKerbHeight.kt
@@ -10,6 +10,7 @@ import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BLIND
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.WHEELCHAIR
+import de.westnordost.streetcomplete.osm.PATH_FOR_FOOT_AND_CYCLE
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeightForm
@@ -41,7 +42,7 @@ class AddCrossingKerbHeight : OsmElementQuestType<KerbHeight>, AndroidQuest {
     private val excludedWaysFilter by lazy { """
         ways with
           highway and access ~ private|no
-          or highway ~ footway|path|cycleway
+          or highway ~ ${PATH_FOR_FOOT_AND_CYCLE.joinToString("|")}
           or highway = service and service = driveway
           or sidewalk:both ~ none|no
           or sidewalk ~ none|no

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCycleway.kt
@@ -14,6 +14,9 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.osm.LOCAL_ACCESS_ROADS
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.PUBLIC_AND_UNCLASSIFIED
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.cycleway.Cycleway
 import de.westnordost.streetcomplete.osm.cycleway.LeftAndRightCycleway
@@ -117,7 +120,7 @@ class AddCycleway(
 // streets that may have cycleway tagging
 private val roadsFilter by lazy { """
     ways with
-      highway ~ primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|busway|living_street
+      highway ~ ${(MAJOR_ROADS + LOCAL_ACCESS_ROADS + PUBLIC_AND_UNCLASSIFIED + setOf("service")).joinToString("|")}
       and area != yes
       and motorroad != yes
       and expressway != yes

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCyclewayForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/cycleway/AddCyclewayForm.kt
@@ -5,6 +5,8 @@ import android.view.View
 import androidx.appcompat.app.AlertDialog
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.UNCLASSIFIED_ROADS
 import de.westnordost.streetcomplete.osm.cycleway.Cycleway
 import de.westnordost.streetcomplete.osm.cycleway.CyclewayAndDirection
 import de.westnordost.streetcomplete.osm.cycleway.LeftAndRightCycleway
@@ -121,7 +123,7 @@ class AddCyclewayForm : AStreetSideSelectForm<CyclewayAndDirection, LeftAndRight
 
     private val likelyNoBicycleContraflow = """
         ways with oneway:bicycle != no and (
-            oneway ~ yes|-1 and highway ~ primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified
+            oneway ~ yes|-1 and highway ~ ${(MAJOR_ROADS + UNCLASSIFIED_ROADS).joinToString("|")}
             or dual_carriageway = yes
             or junction ~ roundabout|circular
         )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/foot/AddProhibitedForPedestrians.kt
@@ -6,8 +6,11 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
 import de.westnordost.streetcomplete.osm.ROADS_ASSUMED_TO_BE_PAVED
+import de.westnordost.streetcomplete.osm.TRUNKS
 import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.UNCLASSIFIED_ROADS
 import de.westnordost.streetcomplete.osm.surface.PAVED_SURFACES
 import de.westnordost.streetcomplete.quests.foot.ProhibitedForPedestriansAnswer.ACTUALLY_HAS_SIDEWALK
 import de.westnordost.streetcomplete.quests.foot.ProhibitedForPedestriansAnswer.NO
@@ -37,7 +40,7 @@ class AddProhibitedForPedestrians : OsmFilterQuestType<ProhibitedForPedestriansA
            or if already bicycle=no/sidepath */
         // only roads where foot=X is not (almost) implied
         "and motorroad != yes " +
-        "and highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified " +
+        "and highway ~ ${(TRUNKS + MAJOR_ROADS + UNCLASSIFIED_ROADS).joinToString("|")} " +
         // road probably not developed enough to issue a prohibition for pedestrians
         "and (surface ~ ${PAVED_SURFACES.joinToString("|")} or highway ~ ${ROADS_ASSUMED_TO_BE_PAVED.joinToString("|")})" +
         // fuzzy filter for above mentioned situations + developed-enough / non-rural roads

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/incline_direction/AddBicycleIncline.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/incline_direction/AddBicycleIncline.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
+import de.westnordost.streetcomplete.osm.ALL_PATHS_EXCEPT_STEPS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.util.math.measuredLength
 
@@ -16,7 +17,7 @@ class AddBicycleIncline : OsmElementQuestType<BicycleInclineAnswer>, AndroidQues
 
     private val tagFilter by lazy { """
         ways with mtb:scale:uphill
-         and highway ~ footway|cycleway|path|bridleway|track
+         and highway ~ ${(ALL_PATHS_EXCEPT_STEPS + setOf("track")).joinToString("|")}
          and (!indoor or indoor = no)
          and area != yes
          and access !~ private|no

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/lanes/AddLanes.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
 import de.westnordost.streetcomplete.osm.ROADS_ASSUMED_TO_BE_PAVED
+import de.westnordost.streetcomplete.osm.ROADS_WITH_LANES
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.maxspeed.FILTER_IS_IMPLICIT_MAX_SPEED_BUT_NOT_SLOW_ZONE
 import de.westnordost.streetcomplete.osm.surface.PAVED_SURFACES
@@ -95,11 +96,4 @@ class AddLanes : OsmFilterQuestType<LanesAnswer>(), AndroidQuest {
         }
     }
 
-    companion object {
-        private val ROADS_WITH_LANES = listOf(
-            "motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link",
-            "secondary", "secondary_link", "tertiary", "tertiary_link",
-            "unclassified", "busway",
-        )
-    }
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -29,7 +29,7 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer>, AndroidQuest {
     private val roadsWithoutMaxHeightFilter by lazy { """
         ways with
         (
-          highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|track|road|busway
+          highway ~ ${(ALL_ROADS - setOf("service")).joinToString("|")}
           or (highway = service and access !~ private|no and vehicle !~ private|no)
         )
         and $noMaxHeight

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_speed/AddMaxSpeed.kt
@@ -9,6 +9,10 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
+import de.westnordost.streetcomplete.osm.ALL_LINKS
+import de.westnordost.streetcomplete.osm.HIGHWAYS
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.PUBLIC_AND_UNCLASSIFIED
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.maxspeed.MAX_SPEED_TYPE_KEYS
 import de.westnordost.streetcomplete.osm.surface.UNPAVED_SURFACES
@@ -18,7 +22,7 @@ class AddMaxSpeed : OsmFilterQuestType<MaxSpeedAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         ways with
-         highway ~ motorway|trunk|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|busway
+         highway ~ ${(HIGHWAYS + MAJOR_ROADS + PUBLIC_AND_UNCLASSIFIED + setOf("residential") - ALL_LINKS).joinToString("|")}
          and !maxspeed and !maxspeed:advisory and !maxspeed:forward and !maxspeed:backward
          and ${MAX_SPEED_TYPE_KEYS.joinToString(" and ") { "!$it" }}
          and surface !~ ${UNPAVED_SURFACES.joinToString("|")}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
@@ -5,6 +5,10 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.TRUNKS
+import de.westnordost.streetcomplete.osm.LOCAL_ACCESS_ROADS
+import de.westnordost.streetcomplete.osm.PUBLIC_AND_UNCLASSIFIED
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.quests.max_weight.MaxWeightSign.MAX_AXLE_LOAD
 import de.westnordost.streetcomplete.quests.max_weight.MaxWeightSign.MAX_GROSS_VEHICLE_MASS
@@ -15,7 +19,7 @@ class AddMaxWeight : OsmFilterQuestType<MaxWeightAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         ways with
-         highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service|busway
+         highway ~ ${(TRUNKS + MAJOR_ROADS + LOCAL_ACCESS_ROADS + PUBLIC_AND_UNCLASSIFIED + setOf("service")).joinToString("|")}
          and bridge and bridge != no
          and service != driveway
          and !maxweight and maxweight:signed != no

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/road_name/AddRoadName.kt
@@ -8,6 +8,11 @@ import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.POSTMAN
+import de.westnordost.streetcomplete.osm.ALL_LINKS
+import de.westnordost.streetcomplete.osm.LOCAL_ACCESS_ROADS
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.PEDESTRIAN_ONLY_ROADS
+import de.westnordost.streetcomplete.osm.PUBLIC_AND_UNCLASSIFIED
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.localized_name.LocalizedName
 import de.westnordost.streetcomplete.osm.localized_name.applyTo
@@ -16,7 +21,7 @@ class AddRoadName : OsmFilterQuestType<RoadNameAnswer>(), AndroidQuest {
 
     override val elementFilter = """
         ways with
-          highway ~ primary|secondary|tertiary|unclassified|residential|living_street|pedestrian|busway
+          highway ~ ${(MAJOR_ROADS + PUBLIC_AND_UNCLASSIFIED + LOCAL_ACCESS_ROADS + PEDESTRIAN_ONLY_ROADS - ALL_LINKS).joinToString("|")}
           and !name and !name:left and !name:right
           and !ref
           and noname != yes

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/segregated/AddCyclewaySegregation.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
+import de.westnordost.streetcomplete.osm.PATH_FOR_FOOT_AND_CYCLE
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.surface.PAVED_SURFACES
 import de.westnordost.streetcomplete.quests.segregated.CyclewaySegregation.*
@@ -20,7 +21,7 @@ class AddCyclewaySegregation : OsmFilterQuestType<CyclewaySegregation>(), Androi
           or (highway = cycleway and foot ~ designated|yes)
           or
             (
-            highway ~ path|footway|cycleway
+            highway ~ ${PATH_FOR_FOOT_AND_CYCLE.joinToString("|")}
             and (footway:surface or cycleway:surface)
             and foot !~ private|no
             and bicycle !~ private|no
@@ -30,7 +31,7 @@ class AddCyclewaySegregation : OsmFilterQuestType<CyclewaySegregation>(), Androi
         and area != yes
         and !(sidewalk or sidewalk:left or sidewalk:right or sidewalk:both)
         and !segregated
-        and ~path|footway|cycleway !~ link
+        and ~${PATH_FOR_FOOT_AND_CYCLE.joinToString("|")} !~ link
     """
     override val changesetComment = "Specify whether combined foot- and cycleways are segregated"
     override val wikiLink = "Key:segregated"

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk/AddSidewalk.kt
@@ -9,7 +9,14 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.osm.ALL_MAJOR_AND_HIGHWAYS
+import de.westnordost.streetcomplete.osm.HIGHWAYS
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.PUBLIC_AND_UNCLASSIFIED
+import de.westnordost.streetcomplete.osm.TERTIARY
+import de.westnordost.streetcomplete.osm.TRUNKS
 import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.UNCLASSIFIED_ROADS
 import de.westnordost.streetcomplete.osm.maxspeed.MAX_SPEED_TYPE_KEYS
 import de.westnordost.streetcomplete.osm.sidewalk.LeftAndRightSidewalk
 import de.westnordost.streetcomplete.osm.sidewalk.Sidewalk.INVALID
@@ -58,14 +65,14 @@ private val roadsFilter by lazy { """
     ways with
       (
         (
-          highway ~ trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|busway
+          highway ~ ${(TRUNKS + MAJOR_ROADS + PUBLIC_AND_UNCLASSIFIED + setOf("residential", "service")).joinToString("|")}
           and motorroad != yes
           and expressway != yes
           and foot != no
         )
         or
         (
-          highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|busway
+          highway ~ ${(ALL_MAJOR_AND_HIGHWAYS + PUBLIC_AND_UNCLASSIFIED + setOf("residential", "service")).joinToString("|")}
           and (foot ~ yes|designated or bicycle ~ yes|designated)
         )
       )
@@ -85,7 +92,7 @@ private val roadsFilter by lazy { """
  */
 private val untaggedRoadsFilter by lazy { """
     ways with
-      highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential
+      highway ~ ${(ALL_MAJOR_AND_HIGHWAYS + UNCLASSIFIED_ROADS + setOf("residential")).joinToString("|")}
       and !sidewalk and !sidewalk:both and !sidewalk:left and !sidewalk:right
       and (!maxspeed or maxspeed > 9 or maxspeed ~ [A-Z].*)
       and surface !~ ${UNPAVED_SURFACES.joinToString("|")}
@@ -94,7 +101,7 @@ private val untaggedRoadsFilter by lazy { """
         or highway = residential
         or ~"${MAX_SPEED_TYPE_KEYS.joinToString("|")}" ~ ".*:(urban|.*zone.*|nsl_restricted)"
         or maxspeed <= 60
-        or (foot ~ yes|designated and highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link)
+        or (foot ~ yes|designated and highway ~ ${(ALL_MAJOR_AND_HIGHWAYS - TERTIARY).joinToString("|")})
       )
       and ~foot|bicycle|bicycle:backward|bicycle:forward !~ use_sidepath
       and ~cycleway|cycleway:left|cycleway:right|cycleway:both !~ separate

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/AddPathSmoothness.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.WHEELCHAIR
+import de.westnordost.streetcomplete.osm.ALL_PATHS_EXCEPT_STEPS
 import de.westnordost.streetcomplete.osm.Tags
 
 class AddPathSmoothness : OsmFilterQuestType<SmoothnessAnswer>(), AndroidQuest {
@@ -40,6 +41,3 @@ class AddPathSmoothness : OsmFilterQuestType<SmoothnessAnswer>(), AndroidQuest {
         answer.applyTo(tags)
     }
 }
-
-// smoothness is not asked for steps
-val ALL_PATHS_EXCEPT_STEPS = listOf("footway", "cycleway", "path", "bridleway")

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/smoothness/AddRoadSmoothness.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
+import de.westnordost.streetcomplete.osm.ROADS_TO_ASK_SMOOTHNESS_FOR
 import de.westnordost.streetcomplete.osm.Tags
 
 class AddRoadSmoothness : OsmFilterQuestType<SmoothnessAnswer>(), AndroidQuest {
@@ -49,11 +50,4 @@ class AddRoadSmoothness : OsmFilterQuestType<SmoothnessAnswer>(), AndroidQuest {
 // should only contain values that are in the Surface class
 val SURFACES_FOR_SMOOTHNESS = listOf(
     "asphalt", "concrete", "concrete:plates", "sett", "paving_stones", "compacted", "gravel", "fine_gravel"
-)
-
-private val ROADS_TO_ASK_SMOOTHNESS_FOR = arrayOf(
-    // "trunk","trunk_link","motorway","motorway_link", // too much, motorways are almost by definition smooth asphalt (or concrete)
-    "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link",
-    "unclassified", "residential", "living_street", "pedestrian", "track", "busway",
-    // "service", // this is too much (e.g. includes driveways), and the information value is very low
 )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -8,6 +8,7 @@ import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.OUTDOORS
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.WHEELCHAIR
+import de.westnordost.streetcomplete.osm.ALL_PATHS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.changeToSteps
 import de.westnordost.streetcomplete.osm.surface.INVALID_SURFACES
@@ -16,7 +17,7 @@ import de.westnordost.streetcomplete.osm.surface.applyTo
 class AddPathSurface : OsmFilterQuestType<SurfaceOrIsStepsAnswer>(), AndroidQuest {
 
     override val elementFilter = """
-        ways with highway ~ path|footway|cycleway|bridleway|steps
+        ways with highway ~ ${ALL_PATHS.joinToString("|")}
         and segregated != yes
         and access !~ private|no
         and (!conveying or conveying = no)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -6,6 +6,8 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
+import de.westnordost.streetcomplete.osm.ALL_ROADS
+import de.westnordost.streetcomplete.osm.HIGHWAYS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.surface.INVALID_SURFACES
 import de.westnordost.streetcomplete.osm.surface.INVALID_SURFACES_FOR_TRACKTYPES
@@ -17,10 +19,7 @@ class AddRoadSurface : OsmFilterQuestType<Surface>(), AndroidQuest {
 
     override val elementFilter = """
         ways with (
-          highway ~ ${listOf(
-            "primary", "primary_link", "secondary", "secondary_link", "tertiary", "tertiary_link",
-            "unclassified", "residential", "living_street", "pedestrian", "track", "busway",
-            ).joinToString("|")
+          highway ~ ${(ALL_ROADS - HIGHWAYS - setOf("road")).joinToString("|")
           }
           or highway = service and service !~ driveway|slipway
         )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddSidewalkSurface.kt
@@ -6,6 +6,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.WHEELCHAIR
+import de.westnordost.streetcomplete.osm.ALL_ROADS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.removeCheckDatesForKey
 import de.westnordost.streetcomplete.osm.sidewalk_surface.applyTo
@@ -15,7 +16,7 @@ class AddSidewalkSurface : OsmFilterQuestType<SidewalkSurfaceAnswer>(), AndroidQ
     // Only roads with 'complete' sidewalk tagging (at least one side has sidewalk, other side specified)
     override val elementFilter = """
         ways with
-          highway ~ motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|service|living_street|busway
+          highway ~ ${(ALL_ROADS - setOf("track", "road")).joinToString("|")}
           and area != yes
           and (
             sidewalk ~ both|left|right

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/way_lit/AddWayLit.kt
@@ -5,6 +5,9 @@ import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.PEDESTRIAN
+import de.westnordost.streetcomplete.osm.LIT_NON_RESIDENTIAL_ROADS
+import de.westnordost.streetcomplete.osm.LIT_RESIDENTIAL_ROADS
+import de.westnordost.streetcomplete.osm.LIT_WAYS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.changeToSteps
 import de.westnordost.streetcomplete.osm.lit.applyTo
@@ -64,16 +67,4 @@ class AddWayLit : OsmFilterQuestType<WayLitOrIsStepsAnswer>(), AndroidQuest {
         }
     }
 
-    companion object {
-        private val LIT_RESIDENTIAL_ROADS = arrayOf(
-            "residential", "living_street", "pedestrian", "busway"
-        )
-
-        private val LIT_NON_RESIDENTIAL_ROADS = arrayOf(
-            "motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link",
-            "secondary", "secondary_link", "tertiary", "tertiary_link", "unclassified", "service"
-        )
-
-        private val LIT_WAYS = arrayOf("footway", "cycleway", "steps")
-    }
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/width/AddRoadWidth.kt
@@ -9,7 +9,11 @@ import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
+import de.westnordost.streetcomplete.osm.ALL_LINKS
+import de.westnordost.streetcomplete.osm.MAJOR_ROADS
+import de.westnordost.streetcomplete.osm.PUBLIC_AND_UNCLASSIFIED
 import de.westnordost.streetcomplete.osm.ROADS_ASSUMED_TO_BE_PAVED
+import de.westnordost.streetcomplete.osm.TRUNKS
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.maxspeed.MAX_SPEED_TYPE_KEYS
 import de.westnordost.streetcomplete.osm.surface.PAVED_SURFACES
@@ -29,7 +33,7 @@ class AddRoadWidth(
     private val wayFilter by lazy { """
         ways with (
           (
-            highway ~ trunk|primary|secondary|tertiary|unclassified|residential|busway
+            highway ~ ${(TRUNKS + MAJOR_ROADS + PUBLIC_AND_UNCLASSIFIED + setOf("residential") - ALL_LINKS).joinToString("|")}
             and (lane_markings = no or lanes < 2)
           ) or (
             highway = residential

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/RoadUtils.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/RoadUtils.kt
@@ -9,16 +9,43 @@ val SECONDARY   = setOf("secondary", "secondary_link")
 val TERTIARY    = setOf("tertiary", "tertiary_link")
 val MAJOR_ROADS = PRIMARY + SECONDARY + TERTIARY
 
-val LOCAL_ACCESS_ROADS    = setOf("residential", "living_street")
-val PEDESTRIAN_ONLY_ROADS = setOf("pedestrian")
+val LOCAL_ACCESS_ROADS     = setOf("residential", "living_street")
+val PEDESTRIAN_ONLY_ROADS  = setOf("pedestrian")
+val PUBLIC_TRANSPORT_ROADS = setOf("busway")
+val UNCLASSIFIED_ROADS     = setOf("unclassified")
 
-val OTHER_ROADS = setOf("unclassified", "service", "track", "busway", "road")
+val OTHER_ROADS = setOf("service", "track", "road")
 
-val ALL_ROADS = HIGHWAYS + MAJOR_ROADS + LOCAL_ACCESS_ROADS +
-                PEDESTRIAN_ONLY_ROADS + OTHER_ROADS
+val ALL_MAJOR_AND_HIGHWAYS = HIGHWAYS + MAJOR_ROADS
+val ALL_LINKS = ALL_MAJOR_AND_HIGHWAYS.filter { it.endsWith("_link") }.toSet()
 
-val ALL_PATHS = setOf(
-    "footway", "cycleway", "path", "bridleway", "steps"
-)
+val ALL_ROADS = ALL_MAJOR_AND_HIGHWAYS + LOCAL_ACCESS_ROADS +
+                PEDESTRIAN_ONLY_ROADS + PUBLIC_TRANSPORT_ROADS +
+                UNCLASSIFIED_ROADS + OTHER_ROADS
 
-val ROADS_ASSUMED_TO_BE_PAVED = HIGHWAYS
+val PATH_FOR_FOOT_AND_CYCLE = setOf("path", "footway", "cycleway")
+val PATH_FOR_EQUESTRIANS    = setOf("bridleway")
+val ALL_PATHS = PATH_FOR_FOOT_AND_CYCLE + PATH_FOR_EQUESTRIANS + setOf("steps")
+
+val ALL_PATHS_EXCEPT_STEPS = PATH_FOR_FOOT_AND_CYCLE + PATH_FOR_EQUESTRIANS
+
+val PUBLIC_AND_UNCLASSIFIED =
+    PUBLIC_TRANSPORT_ROADS + UNCLASSIFIED_ROADS
+
+val ROADS_WITH_LANES =
+    ALL_MAJOR_AND_HIGHWAYS + PUBLIC_AND_UNCLASSIFIED
+val ROADS_ASSUMED_TO_BE_PAVED =
+    HIGHWAYS
+val ROADS_TO_ASK_SMOOTHNESS_FOR =
+    ALL_ROADS - MOTORWAYS - OTHER_ROADS + setOf("track")
+val TAGGING_NOT_ASSUMED =
+    MOTORWAYS + PEDESTRIAN_ONLY_ROADS + PUBLIC_TRANSPORT_ROADS +
+        (OTHER_ROADS - setOf("road")) + setOf("living_street")
+
+val LIT_RESIDENTIAL_ROADS =
+    PEDESTRIAN_ONLY_ROADS + LOCAL_ACCESS_ROADS + PUBLIC_TRANSPORT_ROADS
+
+val LIT_NON_RESIDENTIAL_ROADS =
+    ALL_MAJOR_AND_HIGHWAYS + UNCLASSIFIED_ROADS + setOf("service")
+
+val LIT_WAYS = PATH_FOR_FOOT_AND_CYCLE


### PR DESCRIPTION
This draft-PR removes multiple manual lists for `highway` and replaces them with vals defined in `RoadUtils` in lazyFilters.

Reasoning is obvious, should one ever want to change multiple lists this makes it easier to do so, even more so as when val names are descriptive.

Quest-specific lists have been transferred to `RoadUtils` as well.

Feedback is sought for specifics (combinations of sets) or general use of this approach.