### PR TITLE
check for existence of bicycle repair stations

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/existence/CheckExistence.kt
@@ -44,6 +44,7 @@ class CheckExistence(
             or amenity = grit_bin and seasonal = no
             or amenity = vending_machine and vending ~ parking_tickets|public_transport_tickets
             or amenity = ticket_validator
+            or amenity = bicycle_repair_station
             or tourism = information and information ~ board|terminal|map
             or advertising ~ column|board|poster_box
             or (highway = emergency_access_point or emergency = access_point) and ref


### PR DESCRIPTION
Feels like a small enough map feature to fit into the existence quest. 4 years seemed like the most fitting category. bike repair stations that have not been updated for 4 years are currently quite rare though, mostly due to the new bike repair quest. However I found this node that can serve for testing: https://www.openstreetmap.org/node/6145704153#map=19/54.892393/9.550448&layers=C