### PR TITLE
AddChargingStationCapacity: answer specific capacity

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/AddChargingStationCapacity.kt
@@ -22,14 +22,6 @@ class AddChargingStationCapacity : OsmFilterQuestType<Int>(), AndroidQuest {
           (
             motorcar ~ yes|designated
             or motor_vehicle ~ yes|designated
-            or
-            (
-              !motorcar
-              and !motor_vehicle
-              and bicycle !~ yes|designated
-              and hgv !~ yes|designated
-              and scooter !~ yes|designated
-            )
           )
           and access !~ private|no
     """

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/ChargingStationAccessCount.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/ChargingStationAccessCount.kt
@@ -5,7 +5,12 @@ package de.westnordost.streetcomplete.quests.charging_station_capacity
  */
 fun canBeAccessedByOtherVehicle(tags: Map<String, String>, tag: String): Boolean {
     val accessTags = listOf(
-        "motorcar", "hgv", "bus", "bicycle", "goods", "scooter", "motorcycle",
+        // All access tags with at least one usage.
+        "motorcar", "hgv", "bus", "bicycle", "goods", "scooter", "motorcycle", "electric_bicycle",
+        "cargo_bike", "kick_scooter", "caravan", "moped", "speed_pedelec", "mofa",
+        "small_electric_vehicle", "motorhome", "goods", "nev", "psv", "bus", "taxi", "disabled",
+        "wheelchair", "boat", "ship", "train"
+
     ).filter { it != tag }
     return accessTags.any { accessTag ->
         tags[accessTag].let { it == "designated" || it == "yes" }

--- a/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/ChargingStationCapacityTest.kt
+++ b/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/charging_station_capacity/ChargingStationCapacityTest.kt
@@ -22,12 +22,6 @@ class ChargingStationCapacityTest {
         ))))
     }
 
-    @Test fun `applicable to charging station without vehicle`() {
-        assertTrue(questType.isApplicableTo(node(tags = mapOf(
-            "amenity" to "charging_station"
-        ))))
-    }
-
     @Test fun `not applicable to charging station with only other vehicle set`() {
         assertFalse(questType.isApplicableTo(node(tags = mapOf(
             "amenity" to "charging_station",


### PR DESCRIPTION
A charging station can serve cars, hgv, bikes etc. Most only serve a single one, however some serve multiple modes of transport, for example bikes and cars.
For these the `capacity` tag is ill suited, since it is not specific enough. Currently we simply ignore such elements.
Instead we should use `capacity:motorcar` to clearly specify which form of transport has which capacity.
This PR adds a function that checks if the charging station supports any other vehicles. If yes it uses the more specific `capacity:motorcar` instead.

This was briefly suggested in https://github.com/streetcomplete/StreetComplete/issues/6385
I have tested.