### PR TITLE
expanded AddPitchLit to ski

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/pitch_lit/AddPitchLit.kt
@@ -15,7 +15,7 @@ class AddPitchLit : OsmFilterQuestType<Boolean>(), AndroidQuest {
     override val elementFilter = """
         ways with (
             leisure ~ pitch|track|fitness_station
-            or piste:type
+            or piste:type and !highway
         )
         and (access !~ private|no)
         and indoor != yes and (!building or building = no)


### PR DESCRIPTION
Fixes https://github.com/streetcomplete/StreetComplete/issues/6518.
Instead of implementing this as a new quest, I suggest we expand the existing IsPitchLit quest to ski pistes.
The string "Is this lit here?" already fits well.

It does not ask for piste routes, since these are filtered out (for performance reasons) anyway.