### PR TITLE
highlight other aerialways in AddAerialwayBicycleAccess

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/aerialway/AddAerialwayBicycleAccess.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/aerialway/AddAerialwayBicycleAccess.kt
@@ -1,17 +1,20 @@
 package de.westnordost.streetcomplete.quests.aerialway
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.BICYCLIST
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.RARE
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.quests.aerialway.AerialwayBicycleAccessAnswer.YES
-import de.westnordost.streetcomplete.quests.aerialway.AerialwayBicycleAccessAnswer.SUMMER
-import de.westnordost.streetcomplete.quests.aerialway.AerialwayBicycleAccessAnswer.NO_SIGN
 import de.westnordost.streetcomplete.quests.aerialway.AerialwayBicycleAccessAnswer.NO
-
+import de.westnordost.streetcomplete.quests.aerialway.AerialwayBicycleAccessAnswer.NO_SIGN
+import de.westnordost.streetcomplete.quests.aerialway.AerialwayBicycleAccessAnswer.SUMMER
+import de.westnordost.streetcomplete.quests.aerialway.AerialwayBicycleAccessAnswer.YES
 class AddAerialwayBicycleAccess : OsmFilterQuestType<AerialwayBicycleAccessAnswer>(), AndroidQuest {
 
     override val elementFilter = """
@@ -37,4 +40,9 @@ class AddAerialwayBicycleAccess : OsmFilterQuestType<AerialwayBicycleAccessAnswe
             NO_SIGN -> tags["aerialway:bicycle:signed"] = "no"
         }
     }
-}
+
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("""
+            nodes, ways with aerialway
+        """.toElementFilterExpression())
+    }


### PR DESCRIPTION
Aerialways are not rendered ([and cannot be rendered](https://github.com/streetcomplete/maplibre-streetcomplete-style/issues/5)) on the map. Since at times multiple aerialways may be very close to eachother, with few other landmarks nearby that one can use to differentiate it can be possible to confuse them.
Before:
<img width="572" height="1280" alt="image" src="https://github.com/user-attachments/assets/a24a2152-e9ae-4f0f-afea-4486c89095a4" />
After:
<img width="572" height="1280" alt="image" src="https://github.com/user-attachments/assets/d4c3ad4a-cc9f-44ee-b362-053d851335cf" />
