### PR TITLE
Extended quests to Watchtowers

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/step_count/AddStepCount.kt
@@ -17,7 +17,7 @@ class AddStepCount : OsmFilterQuestType<Int>(), AndroidQuest {
             and (!indoor or indoor = no)
             and (!conveying or conveying = no)
           )
-          or man_made = tower and tower:type = observation and access ~ yes|customers
+          or man_made = tower and access ~ yes|customers and tower:type ~ observation|watchtower
         )
         and access !~ private|no
         and !step_count

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/tower_access/AddTowerAccess.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/tower_access/AddTowerAccess.kt
@@ -12,7 +12,10 @@ class AddTowerAccess : OsmFilterQuestType<TowerAccess>(), AndroidQuest {
     override val elementFilter = """
         nodes, ways, relations with
             man_made = tower
-            and tower:type = observation
+            and (
+                tower:type = observation
+                or tower:type = watchtower and historic=yes
+            )
             and disused != yes
             and !emergency
             and !military

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/wheelchair_access/AddWheelchairAccessOutside.kt
@@ -15,7 +15,7 @@ class AddWheelchairAccessOutside : OsmFilterQuestType<WheelchairAccess>(), Andro
         nodes, ways, relations with
          (
            leisure = dog_park
-           or man_made = tower and tower:type = observation and access ~ yes|customers
+           or man_made = tower and access ~ yes|customers and tower:type ~ observation|watchtower
            or natural = cave_entrance and fee=yes
          )
          and access !~ no|private


### PR DESCRIPTION
Currently we only ask for observation towers, however [watchtowers](https://wiki.openstreetmap.org/wiki/Tag:tower:type%3Dwatchtower) can also be interesting and "visitable". This is most commonly the case if they are `historical=yes`.

Examples:

- Roman watch towers in the [limes](https://en.wikipedia.org/wiki/Limes_(Roman_Empire))
- Former border guard towers (for example along the iron curtain).

I did not extend the AddGeneralFee quest, since there are very few such towers with `fee=yes`, and most of those seem like incorrectly tagged observation towers.