### PR TITLE
expanded maxheight to covered bridges

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_height/AddMaxHeight.kt
@@ -55,7 +55,13 @@ class AddMaxHeight : OsmElementQuestType<MaxHeightAnswer>, AndroidQuest {
     """.toElementFilterExpression() }
 
     private val tunnelFilter by lazy { """
-        ways with highway and (covered = yes or tunnel ~ yes|building_passage|avalanche_protector)
+        ways with
+          highway
+          and (
+            covered = yes
+            or tunnel ~ yes|building_passage|avalanche_protector
+            or bridge = covered
+          )
     """.toElementFilterExpression() }
 
     private val bridgeFilter by lazy { """


### PR DESCRIPTION
Also asks maxheight for bridge=[covered](https://wiki.openstreetmap.org/wiki/Tag:bridge%3Dcovered).

Of the 4583 such bridges 266 currently have maxheight set (5.8%).