### PR TITLE
expand general fee to device charging station

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/general_fee/AddGeneralFee.kt
@@ -25,7 +25,7 @@ class AddGeneralFee : OsmFilterQuestType<Boolean>(), AndroidQuest {
            )
            or tourism ~ museum|gallery|caravan_site|zoo|aquarium|wilderness_hut
            or leisure ~ beach_resort|disc_golf_course
-           or amenity ~ sanitary_dump_station|shower|water_point|public_bath|bicycle_wash|binoculars
+           or amenity ~ sanitary_dump_station|shower|water_point|public_bath|bicycle_wash|binoculars|device_charging_station
            or natural = cave_entrance and access=yes
            or man_made = tower and tower:type = observation and access=yes
          )


### PR DESCRIPTION
Currently device_charging_station (supported as a "thing" since [tagging 6.13.2](https://github.com/openstreetmap/id-tagging-schema/releases/tag/v6.13.2), recommends fee on the [wiki](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Ddevice_charging_station).

Currently the data leans towards `no` with 510 elements, with only 39 tagged `fee=yes`, however since charging stations are quite rare I think this would not be spammy.