### PR TITLE
expanded shower quest to highway=services

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampShower.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampShower.kt
@@ -21,6 +21,7 @@ class AddCampShower : OsmFilterQuestType<Boolean>(), AndroidQuest {
           (
             tourism ~ camp_site|alpine_hut|wilderness_hut
             or leisure = bathing_place
+            or highway = services and toilets = yes
           ) and (
             !shower
             or shower older today -4 years and shower ~ yes|no


### PR DESCRIPTION
Expanded the "AddCampShower" quest to highway=[services](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dservices). Really stretching the "camp" here, but the strings seem to fit well.

Currently 227 have `showers=yes` and only 8 have `showers=no`. Though I strongly suspect this is not reflective of the reality since stations without showers are less likely to have this information added.

I limited this quest to service stations with toilets=yes, since I find it unlikely that places without toilets would have showers, and we already ask for toilets.