### PR TITLE
Remove deflate compression from ContentEncoding

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
@@ -30,6 +30,8 @@ val appModule = module {
         }
         install(ContentEncoding) {
             gzip()
+            // deflate is broken in KTOR, see https://youtrack.jetbrains.com/issue/KTOR-6999/Deflate-ContentEncoder-incorrectly-uses-raw-DEFLATE
+            // deflate()
             identity()
         }
     } }


### PR DESCRIPTION
Removed deflate compression as server can respond with zlib-wrapped DEFLATE format (RFC 1950) which is not supported by the io.ktor.client which I believe only supports raw DEFLATE.

Fixes: #6626