### PR TITLE
expanded AddCampShower to caravan_site

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampShower.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampShower.kt
@@ -19,7 +19,7 @@ class AddCampShower : OsmFilterQuestType<Boolean>(), AndroidQuest {
     override val elementFilter = """
         nodes, ways with
           (
-            tourism ~ camp_site|alpine_hut|wilderness_hut
+            tourism ~ camp_site|alpine_hut|wilderness_hut|caravan_site
             or leisure = bathing_place
             or highway = services and toilets = yes
           ) and (


### PR DESCRIPTION
All the other quests for camp_sites also ask for [tourism](https://wiki.openstreetmap.org/wiki/Key:tourism)=[caravan_site](https://wiki.openstreetmap.org/wiki/Tag:tourism%3Dcaravan_site), with the exception of the AddCampShower quest.

Currently around 1.4k have `shower=yes`, while 400 have `shower=no`.

I have tested this. The string "Can you shower here?" seems to work fine.