### PR TITLE
expanded parking access to motorcycle parking

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/parking_access/AddParkingAccess.kt
@@ -19,7 +19,7 @@ class AddParkingAccess : OsmFilterQuestType<ParkingAccess>(), AndroidQuest {
     // Cf. #2408: Parking access might omit parking=street_side
     // Cf. #4538: should skip elements with more specific access tag already mapped
     override val elementFilter = """
-        nodes, ways, relations with amenity = parking
+        nodes, ways, relations with amenity ~ parking|motorcycle_parking
         and (
             access = unknown
             or (!access and parking !~ street_side|lane) and


### PR DESCRIPTION
The motorcycle fee quest added in https://github.com/streetcomplete/StreetComplete/pull/6532, requires `access=yes`. 

I was planning to suggest a "who may park their motorcycle here?" quest, however I believe simply extending the existing access quest to [motorcycle_parking](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dmotorcycle_parking) is sufficient.

The string "Who is allowed to park here? Parking may be free or paid?" fits well to.

Tested.
