### PR TITLE
expanded AddCampShower to public bath

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampShower.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/camping/AddCampShower.kt
@@ -22,6 +22,7 @@ class AddCampShower : OsmFilterQuestType<Boolean>(), AndroidQuest {
             tourism ~ camp_site|alpine_hut|wilderness_hut|caravan_site
             or leisure = bathing_place
             or highway = services and toilets = yes
+            or amenity = public_bath and fee = no
           ) and (
             !shower
             or shower older today -4 years and shower ~ yes|no


### PR DESCRIPTION
Expands the "AddCampShower" quest to free public baths.
I excluded paid public baths since:

1. The vast majority of these have showers (only 6 do not)
2. They require payment to survey.

Of the public baths with `fee=no` and shower tagged, 17 have `shower=yes`, and 36 `shower=no`.

The string "Are there showers here?" fits well.
Tested.