### PR TITLE
added ref:HU:* keys to be deleted upon replacing places

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Places.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Places.kt
@@ -270,7 +270,7 @@ private val KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED = listOf(
     "name_?[1-9]?(:.*)?", ".*_name_?[1-9]?(:.*)?", "noname", "branch(:.*)?", "brand(:.*)?",
     "not:brand(:.*)?", "network(:.*)?", "operator(:.*)?", "operator_type", "ref", "ref:vatin",
     "designation", "SEP:CLAVEESC", "identifier", "ref:FR:SIRET", "ref:FR:SIREN", "ref:FR:NAF",
-    "(old_)?ref:FR:prix-carburants",
+    "(old_)?ref:FR:prix-carburants", "ref:HU:(company|ntak|om|vatin)",
     // contacts
     "contact_person", "contact(:.*)?", "phone(:.*)?", "phone_?[1-9]?", "emergency:phone",
     "emergency_telephone_code",


### PR DESCRIPTION
The following keys are currently in use in Hungary and their values would make sense to be deleted upon replacing places:

| Key              | Objects | Meaning                                                                                                                                                      |
| ---------------- | -------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `ref:HU:vatin`   | 11 147  | Hungarian VAT identification number (xxxxxxxx-x-xx format – there is also an [OSM wiki article](https://wiki.openstreetmap.org/wiki/Key%3Aref%3AHU%3Avatin)) |
| `ref:HU:company` | 7 823   | Hungarian Company registry number                                                                                                                            |
| `ref:HU:om`      | 438     | Hungarian ID of educational institutions ([OSM wiki article](https://wiki.openstreetmap.org/wiki/Key%3Aref%3AHU%3Aom))                                       |
| `ref:HU:ntak`    | 21      | Hungarian ID of tourism-related businesses                                                                                                                   |

The number in the column _Objects_ contains the number of object within Hungary that have that key according to Taginfo as of 25 December, 2025.