### PR TITLE
Allow selecting multiple board types

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardType.kt
@@ -14,7 +14,7 @@ import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.osm.updateWithCheckDate
 import de.westnordost.streetcomplete.quests.board_type.BoardType.*
 
-class AddBoardType : OsmFilterQuestType<Set<BoardType>>(), AndroidQuest {
+class AddBoardType : OsmFilterQuestType<Set<BoardTypeAnswer>>(), AndroidQuest {
 
     override val elementFilter = """
         nodes with
@@ -36,12 +36,12 @@ class AddBoardType : OsmFilterQuestType<Set<BoardType>>(), AndroidQuest {
 
     override fun createForm() = AddBoardTypeForm()
 
-    override fun applyAnswerTo(answer: Set<BoardType>, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
-        if (answer.isEmpty()) {
+    override fun applyAnswerTo(answer: Set<BoardTypeAnswer>, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        if (answer == setOf(BoardTypeAnswer.NoBoardJustMap)) {
             // Quest cannot be closed with no type selected. This only gets called in confirmOnMap
             tags["information"] = "map"
         } else {
-            val osmValue = answer.joinToString(";") { it.osmValue }
+            val osmValue = answer.joinToString(";") { (it as BoardType).osmValue }
             tags.updateWithCheckDate("board_type", osmValue)
         }
     }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardTypeForm.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_type/AddBoardTypeForm.kt
@@ -9,7 +9,7 @@ import de.westnordost.streetcomplete.quests.AMultipleSelectGroupQuestForm
 import de.westnordost.streetcomplete.quests.AnswerItem
 import org.jetbrains.compose.resources.stringResource
 
-class AddBoardTypeForm : AMultipleSelectGroupQuestForm<BoardType, BoardType>() {
+class AddBoardTypeForm : AMultipleSelectGroupQuestForm<BoardTypeAnswer, BoardType>() {
 
     override val otherAnswers = listOf(
         AnswerItem(R.string.quest_board_type_map) { confirmOnMap() }
@@ -17,7 +17,7 @@ class AddBoardTypeForm : AMultipleSelectGroupQuestForm<BoardType, BoardType>() {
 
     override val items = BoardType.entries
 
-    @Composable override fun BoxScope.ItemContent(item: BoardType) {
+    @Composable override fun BoxScope.ItemContent(item: BoardTypeAnswer) {
         Text(stringResource(item.text))
     }
 
@@ -25,7 +25,9 @@ class AddBoardTypeForm : AMultipleSelectGroupQuestForm<BoardType, BoardType>() {
         AlertDialog.Builder(requireContext())
             .setTitle(R.string.quest_board_type_map_title)
             .setMessage(R.string.quest_board_type_map_description)
-            .setPositiveButton(R.string.quest_generic_hasFeature_yes) { _, _ -> applyAnswer(setOf()) }
+            .setPositiveButton(R.string.quest_generic_hasFeature_yes) { _, _ -> applyAnswer(setOf(
+                BoardTypeAnswer.NoBoardJustMap
+            )) }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
     }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_type/BoardTypeAnswer.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/board_type/BoardTypeAnswer.kt
@@ -14,6 +14,13 @@ import de.westnordost.streetcomplete.resources.quest_board_type_rules
 
 import org.jetbrains.compose.resources.StringResource
 
+sealed interface BoardTypeAnswer {
+    data object NoBoardJustMap : BoardTypeAnswer
+    data class BoardTypes(val boardTypes: Set<BoardType>) : BoardTypeAnswer
+
+}
+
+
 enum class BoardType(val osmValue: String) {
     HISTORY("history"),
     GEOLOGY("geology"),


### PR DESCRIPTION
Fixes #6148

The `information=map`can still be added via the "Uh..." menu. I have achieved this by defining that empty set=map.