### PR TITLE
disable maxweight quest in sweden

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/max_weight/AddMaxWeight.kt
@@ -9,7 +9,9 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Relation
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.mapdata.filter
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
+import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement.CAR
 import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.quests.ferry.wayIdsInFerryRoutes
@@ -89,4 +91,8 @@ class AddMaxWeight : OsmElementQuestType<List<MaxWeight>>, AndroidQuest {
         }
         return false
     }
+
+    override val enabledInCountries = AllCountriesExcept(
+        "SE" // https://github.com/streetcomplete/StreetComplete/issues/6586
+    )
 }


### PR DESCRIPTION
This fixes #6586 by disabling the maxweight quest in sweden entirely.
In the future I might have the time to come back on this and implement the correct signs but for now:

- Due to [imports](https://wiki.openstreetmap.org/wiki/Import/Catalogue/Sweden_highway_import) the maxweight tags are already very common in sweden.
- For the vast majority of remaining bridges, the user currently cannot add this information.