### PR TITLE
Don't use bicycle_road tag in Lithuania

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/bicycle_boulevard/BicycleBoulevard.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/bicycle_boulevard/BicycleBoulevard.kt
@@ -16,8 +16,8 @@ fun BicycleBoulevard.applyTo(tags: Tags, countryCode: String) {
             val useBicycleRoad = when {
                 tags.containsKey("bicycle_road") -> true
                 tags.containsKey("cyclestreet") -> false
-                // in BeNeLux countries, cyclestreet established itself instead
-                countryCode in listOf("BE", "NL", "LU") -> false
+                // in BeNeLux countries (and Lithuania), cyclestreet established itself instead
+                countryCode in listOf("BE", "NL", "LU", "LT") -> false
                 else -> true
             }
             if (useBicycleRoad) {


### PR DESCRIPTION
The bicycle_road streets were recently migrated to use the cyclestreet tag as the legal signage is basically identical to the BeNeLux one (and so it wouldn't make sense to use the other tag anymore)