### PR TITLE
Set icon view tint to avoid black feature icons in dark mode

### DIFF
--- a/app/src/androidMain/res/layout/fragment_overlay_places.xml
+++ b/app/src/androidMain/res/layout/fragment_overlay_places.xml
@@ -21,6 +21,7 @@
             android:layout_width="56dp"
             android:layout_height="56dp"
             tools:src="@drawable/preset_fas_flask"
+            app:tint="@color/text"
             android:padding="4dp"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"

--- a/app/src/androidMain/res/layout/fragment_overlay_things.xml
+++ b/app/src/androidMain/res/layout/fragment_overlay_things.xml
@@ -21,6 +21,7 @@
             android:layout_width="56dp"
             android:layout_height="56dp"
             tools:src="@drawable/preset_fas_flask"
+            app:tint="@color/text"
             android:padding="4dp"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"

--- a/app/src/androidMain/res/layout/view_feature.xml
+++ b/app/src/androidMain/res/layout/view_feature.xml
@@ -14,6 +14,7 @@
         android:layout_width="34dp"
         android:layout_height="34dp"
         tools:src="@drawable/preset_fas_flask"
+        app:tint="@color/text"
         android:padding="4dp"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"


### PR DESCRIPTION
Fixes #6453 and black icons in dark mode when selecting element in overlay.