### PR TITLE
When changing surface, remove more paving_stones:* details

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/surface/SurfaceUtils.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/surface/SurfaceUtils.kt
@@ -112,6 +112,10 @@ fun getKeysAssociatedWithSurface(prefix: String = ""): Set<String> =
         "${prefix}paving_stones:pattern",
         "${prefix}paving_stones:length",
         "${prefix}paving_stones:width",
+        "${prefix}paving_stones:material",
+        "${prefix}paving_stones:colour",
+        "${prefix}paving_stones:orientation",
+        "${prefix}paving_stones:direction",
     ) +
         getLastCheckDateKeys("${prefix}surface") +
         getLastCheckDateKeys("${prefix}smoothness")


### PR DESCRIPTION
We already remove some of documented `paving_stones:*` values, but not all of them - even if some (like `paving_stones:material=*` are more popular then existing listed values)
 
This removes more of them, as per https://wiki.openstreetmap.org/wiki/Tag:surface%3Dpaving_stones#Subtags and https://taginfo.openstreetmap.org/search?q=paving_stones%3A

(have not tested, but looks trivial enough).