### PR TITLE
Add education-related place types to Places.kt

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Places.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Places.kt
@@ -145,6 +145,17 @@ private val IS_PLACE_EXPRESSION by lazy {
             "place_of_worship",
             "public_bath",
         ),
+        "education" to listOf(
+            "college",
+            "dancing_school",
+            "driving_school",
+            "kindergarten",
+            "language_school",
+            "music_school",
+            "prep_school",
+            "school",
+            "university",
+        ),
         "emergency" to listOf(
             "air_rescue_service",
             "ambulance_station",


### PR DESCRIPTION
This PR re-adds driving_school and others to the Places overlay so it can be found and added again from the search dialog.

At the moment, Driving School is no longer discoverable in the overlay even though the preset still exists in the tag editor data as education=driving_school. This change aligns the overlay with the current preset structure and restores the ability to add the feature by searching for either “Driving School” or “Fahrschule”.

The change is intentionally limited to the overlay feature list, so it does not alter existing tagging behavior beyond making the preset searchable again.

**Note**: With this change we can add these places again, but then the POI would be added with `amenity=*` **and** `education=*` with the same value and I don't know why. But it seems to be intended: https://taginfo.openstreetmap.org/tags/education=driving_school

Fixes #6762