### PR TITLE
Make the settings menu more compact

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsScreen.kt
@@ -96,7 +96,8 @@ fun SettingsScreen(
                 Preference(
                     name = stringResource(Res.string.action_manage_presets),
                     onClick = onClickPresetSelection,
-                    description = stringResource(Res.string.action_manage_presets_summary)
+                    description = stringResource(Res.string.action_manage_presets_summary),
+                    useFixedValueWidth = true,
                 ) {
                     Text(
                         text = selectedPresetName ?: stringResource(Res.string.quest_presets_default_name),
@@ -124,7 +125,8 @@ fun SettingsScreen(
                 Preference(
                     name = stringResource(Res.string.pref_title_resurvey_intervals),
                     onClick = { showResurveyIntervalsSelect = true },
-                    description = stringResource(Res.string.pref_title_resurvey_intervals_summary)
+                    description = stringResource(Res.string.pref_title_resurvey_intervals_summary),
+                    useFixedValueWidth = true,
                 ) {
                     Select(
                         items = ResurveyIntervals.entries,
@@ -152,7 +154,8 @@ fun SettingsScreen(
             PreferenceCategory(stringResource(Res.string.pref_category_communication)) {
                 Preference(
                     name = stringResource(Res.string.pref_title_sync2),
-                    onClick = { showAutosyncSelect = true }
+                    onClick = { showAutosyncSelect = true },
+                    useFixedValueWidth = true,
                 ) {
                     Select(
                         items = Autosync.entries,
@@ -174,6 +177,7 @@ fun SettingsScreen(
                 Preference(
                     name = stringResource(Res.string.pref_title_language_select2),
                     onClick = onClickLanguageSelection,
+                    useFixedValueWidth = true,
                 ) {
                     Text(
                         text = selectedLanguage?.let { getLanguageDisplayName(it) }
@@ -186,6 +190,7 @@ fun SettingsScreen(
                 Preference(
                     name = stringResource(Res.string.pref_title_theme_select),
                     onClick = { showThemeSelect = true },
+                    useFixedValueWidth = true,
                 ) {
                     Select(
                         items = Theme.entries,

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/settings/Preference.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/ui/common/settings/Preference.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -60,6 +61,7 @@ fun Preference(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     description: String? = null,
+    useFixedValueWidth: Boolean = false,
     value: @Composable (RowScope.() -> Unit)? = null,
 ) {
     Column(
@@ -80,7 +82,11 @@ fun Preference(
         ) {
             Text(
                 text = name,
-                modifier = Modifier.weight(2 / 3f)
+                modifier = if (value != null && useFixedValueWidth) {
+                    Modifier.weight(0.55f)
+                } else {
+                    Modifier.weight(1f)
+                }
             )
             if (value != null) {
                 CompositionLocalProvider(
@@ -96,7 +102,11 @@ fun Preference(
                             alignment = Alignment.End
                         ),
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.weight(1 / 3f)
+                        modifier = if (useFixedValueWidth) {
+                            Modifier.weight(0.45f)
+                        } else {
+                            Modifier.wrapContentWidth()
+                        }
                     ) { value() }
                 }
             }
@@ -140,6 +150,7 @@ private fun PreferencePreview() {
         Preference(
             name = "Long preference name that wraps",
             onClick = {},
+            useFixedValueWidth = true,
         ) {
             Text("Long preference value")
         }


### PR DESCRIPTION
fix #6751 

Basically there were two things that needed to be done:

1. Give more space for the text of the setting value
2. If there is no text, then give maximum space for the name of the setting. To do this, I added an additional parameter. 

Tested on my Samsung A52:

<details>
<summary>Diff for Russian Localization</summary>

<table>
<tr>
<td>
	Before:
<td>
	After:
<tr>
 <td>

![](https://github.com/user-attachments/assets/760fbe08-5f2e-4910-8e1d-79da7cb6bc09)


 <td>

![](https://github.com/user-attachments/assets/739a2dc1-11d7-485d-8a4a-f49d118f7322)


</table>


</details>

<details>
<summary>Diff for English localization</summary>

<table>
<tr>
<td>
	Before:
<td>
	After:
<tr>
 <td>

![](https://github.com/user-attachments/assets/00b64473-74b7-4dcb-856a-46de237315f8)


 <td>

![](https://github.com/user-attachments/assets/6488724f-aed8-4077-8dee-382b5e7c5230)


</table>

</details>

<details>
<summary>Diff for Espanol (Argentia) localization</summary>

<table>
<tr>
<td>
	Before:
<td>
	After:
<tr>
 <td>

![](https://github.com/user-attachments/assets/86c225e4-ee60-4894-81b8-6267aeaff1ea)

 <td>

![](https://github.com/user-attachments/assets/5c889976-aad4-4e3d-9866-60c5818283db)

</table>

</details>

p.s. I'm not a mobile developer, so I do not know if it can be done more beautifully. However, as you can see, the solution to the problem described in the issue is not very complicated