### PR TITLE
Replace Android-only isDigitsOnly() with Kotlin stdlib for iOS compatibility

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/BlockStepperButton.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/quests/address/BlockStepperButton.kt
@@ -3,7 +3,6 @@ package de.westnordost.streetcomplete.quests.address
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.core.text.isDigitsOnly
 import de.westnordost.streetcomplete.ui.common.StepperButton
 
 /** Stepper button to increase/decrease block (numbers). Will increase or decrease block numbers and
@@ -28,7 +27,7 @@ fun BlockStepperButton(
 
 private fun stepBlock(value: String, step: Int): String? {
     // step block numbers
-    if (value.isNotEmpty() && value.isDigitsOnly()) {
+    if (value.isNotEmpty() && value.all { it.isDigit() }) {
         val result = value.toInt() + step
         if (result < 1) return null
         return result.toString()


### PR DESCRIPTION
`BlockStepperButton.kt` in `commonMain` imports `androidx.core.text.isDigitsOnly`, which is an Android-only extension and unavailable when compiling for iOS targets.

Replace it with the equivalent `value.all { it.isDigit() }` from the Kotlin stdlib, which works on all platforms. Behaviour is identical: both check that every character in the string is a digit.

Part of the iOS port effort (#5421).

I'm excited by the idea of an iOS port for StreetComplete, so that I can stop tethering my old Android tablet to my phone while I'm out on walks. I figured I could get off my butt and start helping a bit. This problem (and the next one) seem to be small iOS compat issues that would be good-first-fixes for me.