### PR TITLE
expanded quests to public baths

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/opening_hours/AddOpeningHours.kt
@@ -58,6 +58,7 @@ mapOf(
 
         // name & opening hours
         "boat_rental", "vehicle_inspection", "motorcycle_rental", "crematorium",
+        "public_bath",
 
         // not ATM because too often it's simply 24/7 and too often it is confused with
         // a bank that might be just next door because the app does not tell the user what

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/place_name/AddPlaceName.kt
@@ -54,6 +54,7 @@ class AddPlaceName(
 
                 // name & opening hours
                 "boat_rental", "vehicle_inspection", "motorcycle_rental", "crematorium",
+                "public_bath",
 
                 // name & wheelchair
                 "theatre",                                        // culture


### PR DESCRIPTION
Adds [public baths](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dpublic_bath) to the opening hour and place name quests.

77.11% of public baths already have a name, and according to the wiki they should have signs, so I assume pretty much all of them will have a name of some kind.

Only 10% have opening hours signed, I suspect there will be quite a few with `opening_hours=24/7` but not enough to be spammy, since these are somewhat rare places.