### PR TITLE
Winter road exclude

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddPathSurface.kt
@@ -34,6 +34,7 @@ class AddPathSurface : OsmFilterQuestType<SurfaceOrIsStepsAnswer>(), AndroidQues
           or surface older today -8 years
         )
         and ~path|footway|cycleway|bridleway !~ link
+        and ice_road != yes
     """
 
     override val changesetComment = "Specify path surfaces"

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/surface/AddRoadSurface.kt
@@ -41,6 +41,7 @@ class AddRoadSurface : OsmFilterQuestType<Surface>(), AndroidQuest {
           }}
         )
         and (access !~ private|no or (foot and foot !~ private|no))
+        and ice_road != yes
     """
 
     override val changesetComment = "Specify road surfaces"

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/tracktype/AddTracktype.kt
@@ -23,6 +23,7 @@ class AddTracktype : OsmFilterQuestType<Tracktype>(), AndroidQuest {
         )
         and (access !~ private|no or (foot and foot !~ private|no))
         and !bridge
+        and ice_road != yes
     """
     // ~paved tracks are less likely to change the surface type
     override val changesetComment = "Specify tracktypes"


### PR DESCRIPTION
Excludes highways with [ice_road](https://wiki.openstreetmap.org/wiki/Key:ice_road)=yes from the surface quests.

Reasoning:

1. The correct answers (`ice`) are not supported by SC.
2. This wastes surveyor time, since it is already obvious that the surface is `ice`. Could be added with an automated edit instead.
3. Since ice roads are commonly seasonal, the user might be confused when they are asked about a road they cannot see.